### PR TITLE
Redirect to client app after email verification

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -156,6 +156,8 @@ pub struct RegisterRequest {
     pub nsec: Option<String>, // Optional: user can provide their own nsec/hex secret key
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relays: Option<Vec<String>>, // Optional: user's preferred relays
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<String>, // Optional: where to redirect after email verification
 }
 
 #[derive(Debug, Serialize)]
@@ -672,6 +674,11 @@ pub async fn register(
     // Password hash is NULL initially - will be set by bcrypt worker
     // Returns Err(RepositoryError::Duplicate) if email already exists, which maps to AuthError::EmailAlreadyExists
     let user_repo = UserRepository::new(pool.clone());
+    // Validate redirect_uri if provided (must be HTTPS or localhost HTTP)
+    let redirect_uri = req.redirect_uri.as_deref().filter(|uri| {
+        uri.starts_with("https://") || uri.starts_with("http://localhost")
+    });
+
     user_repo
         .register_with_personal_key(
             &public_key.to_hex(),
@@ -681,6 +688,7 @@ pub async fn register(
             &verification_token,
             verification_expires,
             &encrypted_secret,
+            redirect_uri,
         )
         .await?;
 
@@ -1545,13 +1553,22 @@ pub async fn verify_email(
         ucan_token
     );
 
+    // If the registration included a redirect_uri, redirect back to the client app
+    let redirect_to = token_data.redirect_uri.map(|uri| {
+        if uri.contains('?') {
+            format!("{}&verified=1", uri)
+        } else {
+            format!("{}?verified=1", uri)
+        }
+    });
+
     Ok((
         axum::http::StatusCode::OK,
         [(axum::http::header::SET_COOKIE, cookie)],
         axum::Json(VerifyEmailResponse {
             success: true,
             message: "Email verified successfully! You are now logged in.".to_string(),
-            redirect_to: None,
+            redirect_to,
             authenticated: Some(true),
             status: None,
             retry_after: None,

--- a/core/src/repositories/user.rs
+++ b/core/src/repositories/user.rs
@@ -16,6 +16,7 @@ pub struct VerificationTokenData {
     pub password_hash: Option<String>,
     pub created_at: DateTime<Utc>,
     pub email_verified: bool,
+    pub redirect_uri: Option<String>,
 }
 
 /// User details returned by admin lookup.
@@ -323,6 +324,7 @@ impl UserRepository {
         verification_token: &str,
         verification_expires_at: DateTime<Utc>,
         encrypted_secret: &[u8],
+        redirect_uri: Option<&str>,
     ) -> Result<(), RepositoryError> {
         let mut tx = self.pool.begin().await?;
         let now = Utc::now();
@@ -330,8 +332,8 @@ impl UserRepository {
         // Insert user with email verification token
         // password_hash may be NULL for async bcrypt flow (computed in background)
         sqlx::query(
-            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, email_verification_expires_at, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            "INSERT INTO users (pubkey, tenant_id, email, password_hash, email_verified, email_verification_token, email_verification_expires_at, redirect_uri, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         )
         .bind(pubkey)
         .bind(tenant_id)
@@ -340,6 +342,7 @@ impl UserRepository {
         .bind(false)
         .bind(verification_token)
         .bind(verification_expires_at)
+        .bind(redirect_uri)
         .bind(now)
         .bind(now)
         .execute(&mut *tx)
@@ -373,7 +376,7 @@ impl UserRepository {
         tenant_id: i64,
     ) -> Result<Option<VerificationTokenData>, RepositoryError> {
         sqlx::query_as(
-            "SELECT pubkey, email_verification_expires_at, password_hash, created_at, email_verified FROM users
+            "SELECT pubkey, email_verification_expires_at, password_hash, created_at, email_verified, redirect_uri FROM users
              WHERE email_verification_token = $1 AND tenant_id = $2",
         )
         .bind(token)

--- a/database/migrations/20260412000000_add_user_redirect_uri.sql
+++ b/database/migrations/20260412000000_add_user_redirect_uri.sql
@@ -1,0 +1,3 @@
+-- Add redirect_uri to users table for post-verification redirect
+-- When a client app registers a user, it can specify where to redirect after email verification
+ALTER TABLE users ADD COLUMN redirect_uri TEXT;


### PR DESCRIPTION
## Summary

- Adds optional `redirect_uri` parameter to `/api/auth/register` so client apps can specify where users should return after email verification
- Stores `redirect_uri` in the `users` table and returns it as `redirect_to` in the verify-email response
- Frontend already handles `redirect_to` (OAuth redirect logic), so no frontend changes needed

Closes #12

## Changes

| File | What |
|------|------|
| `database/migrations/20260412000000_add_user_redirect_uri.sql` | Adds nullable `redirect_uri` column to `users` |
| `core/src/repositories/user.rs` | Stores/retrieves `redirect_uri` in registration and verification queries |
| `api/src/api/http/auth.rs` | Accepts `redirect_uri` on register, validates it (HTTPS or localhost), returns it after verification with `?verified=1` |

## How it works

1. Client app sends `POST /api/auth/register` with `redirect_uri: "https://account.staging.synvya.com"`
2. Keycast stores it alongside the verification token
3. After email verification, backend returns `redirect_to: "https://account.staging.synvya.com?verified=1"`
4. Existing frontend redirect logic kicks in — user lands back on the client app

## Client-side change required

The Synvya account app needs to include `redirect_uri` in its registration request body.

## Test plan

- [ ] Register with `redirect_uri` set → verify email → confirm redirect to client app with `?verified=1`
- [ ] Register without `redirect_uri` → verify email → confirm existing behavior (redirect to `/`)
- [ ] Register with invalid `redirect_uri` (e.g. `ftp://...`) → confirm it's silently ignored
- [ ] Re-verify already-verified email → confirm no redirect (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)