### PR TITLE
Add team invite by email

### DIFF
--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -245,6 +245,21 @@ pub fn api_routes(
             delete(teams::delete_authorization),
         )
         .route("/teams/:id/policies", post(teams::add_policy))
+        .route("/teams/:id/invite", post(teams::invite_user))
+        .route("/teams/:id/invitations", get(teams::list_invitations))
+        .route(
+            "/teams/:id/invitations/:invitation_id",
+            delete(teams::revoke_invitation),
+        )
+        .with_state(pool.clone());
+
+    // Invitation routes (mixed auth: preview is public, accept requires auth)
+    let invitation_preview_route = Router::new()
+        .route("/invitations/preview", get(teams::preview_invitation))
+        .with_state(pool.clone());
+
+    let invitation_accept_route = Router::new()
+        .route("/invitations/accept", post(teams::accept_invitation))
         .with_state(pool);
 
     // Combine routes
@@ -269,6 +284,8 @@ pub fn api_routes(
         .merge(signing_routes.layer(public_cors.clone()))
         .merge(nostr_rpc_routes.layer(public_cors.clone())) // NIP-46 RPC for OAuth apps
         .merge(team_routes.layer(auth_cors.clone())) // Team routes need credentials
+        .merge(invitation_preview_route.layer(public_cors.clone())) // Public - preview invite without auth
+        .merge(invitation_accept_route.layer(auth_cors.clone())) // Auth - accept invite needs session
         .merge(discovery_route.layer(public_cors.clone()))
         .merge(policy_routes.layer(public_cors.clone())) // Public - available to third-party OAuth apps
         .merge(headless_routes.layer(public_cors.clone())) // Public CORS - embedded flow for web + mobile (PKCE protects token exchange)

--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -5,6 +5,7 @@ use axum::{
     Json,
 };
 use secrecy::ExposeSecret;
+use serde::{Deserialize, Serialize};
 
 use nostr_sdk::prelude::*;
 
@@ -21,7 +22,7 @@ use keycast_core::types::authorization::{Authorization, AuthorizationWithRelatio
 use keycast_core::types::policy::PolicyWithPermissions;
 use keycast_core::types::stored_key::PublicStoredKey;
 use keycast_core::types::team::{KeyWithRelations, Team, TeamWithRelations};
-use keycast_core::types::user::TeamUser;
+use keycast_core::types::user::{TeamUser, TeamUserRole};
 
 pub async fn list_teams(
     tenant: crate::api::tenant::TenantExtractor,
@@ -528,5 +529,361 @@ pub async fn verify_admin<'a>(
             "You are not authorized to access this team",
         )),
         Err(_) => Err(ApiError::auth("Failed to verify admin status")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Team invitation handlers
+// ---------------------------------------------------------------------------
+
+use keycast_core::repositories::TeamInvitationRepository;
+use keycast_core::types::team_invitation::{
+    generate_invitation_token, InvitationListItem, InvitationPreview,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct InviteRequest {
+    pub email: String,
+    pub role: TeamUserRole,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status")]
+pub enum InviteResponse {
+    #[serde(rename = "added")]
+    Added { member: TeamUser },
+    #[serde(rename = "invited")]
+    Invited { invitation: InvitationListItem },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AcceptInvitationRequest {
+    pub token: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AcceptInvitationResponse {
+    pub team_id: i32,
+    pub role: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PreviewQuery {
+    pub token: String,
+}
+
+/// POST /api/teams/:id/invite
+/// Invite a user to a team by email. If the user already exists, add them immediately.
+/// Otherwise, create an invitation and send an email.
+pub async fn invite_user(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(pool): State<PgPool>,
+    UcanAuth {
+        pubkey: user_pubkey_hex,
+        ..
+    }: UcanAuth,
+    Path(team_id): Path<i32>,
+    Json(request): Json<InviteRequest>,
+) -> ApiResult<Json<InviteResponse>> {
+    let tenant_id = tenant.0.id;
+    verify_admin(&pool, &user_pubkey_hex, team_id, tenant_id).await?;
+
+    // Normalize email
+    let email = request.email.trim().to_lowercase();
+
+    // Basic email validation
+    if !email.contains('@') || email.len() < 5 {
+        return Err(ApiError::bad_request("Invalid email address"));
+    }
+
+    let role_str = request.role.as_str();
+    let user_repo = UserRepository::new(pool.clone());
+    let team_repo = TeamRepository::new(pool.clone());
+    let invite_repo = TeamInvitationRepository::new(pool.clone());
+
+    // Check if calling user is inviting themselves
+    let caller_email: Option<String> =
+        sqlx::query_scalar("SELECT email FROM users WHERE pubkey = $1 AND tenant_id = $2")
+            .bind(&user_pubkey_hex)
+            .bind(tenant_id)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| ApiError::internal(format!("Failed to look up caller email: {}", e)))?;
+
+    if let Some(ref caller_email) = caller_email {
+        if caller_email.to_lowercase() == email {
+            return Err(ApiError::bad_request("Cannot invite yourself"));
+        }
+    }
+
+    // Check if user with this email already exists
+    let existing_pubkey = user_repo.find_pubkey_by_email(&email, tenant_id).await?;
+
+    match existing_pubkey {
+        Some(pubkey) => {
+            // User exists — add directly
+            if team_repo.is_member(team_id, &pubkey).await? {
+                return Err(ApiError::conflict("Already a team member"));
+            }
+
+            // Ensure user record exists
+            let pk = PublicKey::from_hex(&pubkey)
+                .map_err(|_| ApiError::internal("Invalid stored pubkey"))?;
+            user_repo.find_or_create(tenant_id, &pk).await?;
+
+            let team_user = team_repo.add_member(team_id, &pubkey, role_str).await?;
+            Ok(Json(InviteResponse::Added { member: team_user }))
+        }
+        None => {
+            // User does not exist — create invitation
+            if invite_repo
+                .find_pending_by_email(team_id, &email)
+                .await?
+                .is_some()
+            {
+                return Err(ApiError::conflict(
+                    "Invitation already pending for this email",
+                ));
+            }
+
+            let token = generate_invitation_token();
+
+            let invitation = invite_repo
+                .create(
+                    team_id,
+                    tenant_id,
+                    &email,
+                    role_str,
+                    &token,
+                    &user_pubkey_hex,
+                )
+                .await?;
+
+            // Resolve inviter display name
+            let inviter_name = resolve_display_name(&pool, &user_pubkey_hex, tenant_id).await;
+
+            // Resolve team name
+            let team = team_repo.find(tenant_id, team_id).await?;
+
+            // Build invite URL
+            let invite_base_url = std::env::var("INVITE_BASE_URL")
+                .or_else(|_| std::env::var("BASE_URL"))
+                .or_else(|_| std::env::var("APP_URL"))
+                .unwrap_or_else(|_| "http://localhost:5173".to_string());
+            let invite_url = format!("{}/accept-invite?token={}", invite_base_url, token);
+
+            // Send invitation email
+            match crate::email_service::EmailService::new().await {
+                Ok(email_service) => {
+                    if let Err(e) = email_service
+                        .send_team_invite_email(
+                            &email,
+                            &team.name,
+                            &inviter_name,
+                            role_str,
+                            &invite_url,
+                        )
+                        .await
+                    {
+                        tracing::error!("Failed to send team invite email to {}: {}", email, e);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to initialize email service: {}", e);
+                }
+            }
+
+            let list_item = InvitationListItem {
+                id: invitation.id,
+                email: invitation.email,
+                role: invitation.role,
+                invited_by: inviter_name,
+                created_at: invitation.created_at,
+                expires_at: invitation.expires_at,
+                accepted_at: invitation.accepted_at,
+                revoked_at: invitation.revoked_at,
+            };
+
+            Ok(Json(InviteResponse::Invited {
+                invitation: list_item,
+            }))
+        }
+    }
+}
+
+/// GET /api/teams/:id/invitations
+/// List all invitations for a team.
+pub async fn list_invitations(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(pool): State<PgPool>,
+    UcanAuth {
+        pubkey: user_pubkey_hex,
+        ..
+    }: UcanAuth,
+    Path(team_id): Path<i32>,
+) -> ApiResult<Json<Vec<InvitationListItem>>> {
+    let tenant_id = tenant.0.id;
+    verify_admin(&pool, &user_pubkey_hex, team_id, tenant_id).await?;
+
+    let invite_repo = TeamInvitationRepository::new(pool.clone());
+    let invitations = invite_repo.list_by_team(team_id, tenant_id).await?;
+
+    // Collect unique inviter pubkeys for batch display name resolution
+    let mut items = Vec::with_capacity(invitations.len());
+    for inv in invitations {
+        let inviter_name = resolve_display_name(&pool, &inv.invited_by, tenant_id).await;
+        items.push(InvitationListItem {
+            id: inv.id,
+            email: inv.email,
+            role: inv.role,
+            invited_by: inviter_name,
+            created_at: inv.created_at,
+            expires_at: inv.expires_at,
+            accepted_at: inv.accepted_at,
+            revoked_at: inv.revoked_at,
+        });
+    }
+
+    Ok(Json(items))
+}
+
+/// DELETE /api/teams/:id/invitations/:invitation_id
+/// Revoke a pending invitation.
+pub async fn revoke_invitation(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(pool): State<PgPool>,
+    UcanAuth {
+        pubkey: user_pubkey_hex,
+        ..
+    }: UcanAuth,
+    Path((team_id, invitation_id)): Path<(i32, i32)>,
+) -> ApiResult<StatusCode> {
+    let tenant_id = tenant.0.id;
+    verify_admin(&pool, &user_pubkey_hex, team_id, tenant_id).await?;
+
+    let invite_repo = TeamInvitationRepository::new(pool.clone());
+    invite_repo
+        .revoke(invitation_id, team_id, tenant_id)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// GET /api/invitations/preview?token=...
+/// Public endpoint — returns enough info to render the invite landing page.
+pub async fn preview_invitation(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(pool): State<PgPool>,
+    axum::extract::Query(query): axum::extract::Query<PreviewQuery>,
+) -> ApiResult<Json<InvitationPreview>> {
+    let tenant_id = tenant.0.id;
+
+    let invite_repo = TeamInvitationRepository::new(pool.clone());
+    let invitation = invite_repo
+        .find_valid_by_token(&query.token)
+        .await?
+        .ok_or_else(|| ApiError::not_found("Invitation not found or expired"))?;
+
+    // Verify tenant match
+    if invitation.tenant_id != tenant_id {
+        return Err(ApiError::not_found("Invitation not found or expired"));
+    }
+
+    // Resolve team name
+    let team_repo = TeamRepository::new(pool.clone());
+    let team = team_repo.find(tenant_id, invitation.team_id).await?;
+
+    // Resolve inviter display name
+    let inviter_name = resolve_display_name(&pool, &invitation.invited_by, tenant_id).await;
+
+    Ok(Json(InvitationPreview {
+        team_name: team.name,
+        role: invitation.role,
+        invited_by_display_name: inviter_name,
+        expires_at: invitation.expires_at,
+    }))
+}
+
+/// POST /api/invitations/accept
+/// Accept a team invitation. Requires authenticated session.
+pub async fn accept_invitation(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(pool): State<PgPool>,
+    UcanAuth {
+        pubkey: user_pubkey_hex,
+        ..
+    }: UcanAuth,
+    Json(request): Json<AcceptInvitationRequest>,
+) -> ApiResult<Json<AcceptInvitationResponse>> {
+    let tenant_id = tenant.0.id;
+
+    let invite_repo = TeamInvitationRepository::new(pool.clone());
+
+    // Find valid invitation
+    let invitation = invite_repo
+        .find_valid_by_token(&request.token)
+        .await?
+        .ok_or_else(|| ApiError::not_found("Invitation not found or expired"))?;
+
+    // Verify tenant match
+    if invitation.tenant_id != tenant_id {
+        return Err(ApiError::not_found("Invitation not found or expired"));
+    }
+
+    // Get the authenticated user's email
+    let user_repo = UserRepository::new(pool.clone());
+    let user_email: String = user_repo
+        .get_email(&user_pubkey_hex, tenant_id)
+        .await
+        .map_err(|_| ApiError::bad_request("Could not retrieve your email address"))?;
+
+    // Verify email match (case-insensitive)
+    if user_email.to_lowercase() != invitation.email.to_lowercase() {
+        return Err(ApiError::forbidden(
+            "This invitation was sent to a different email address",
+        ));
+    }
+
+    // Check if already a team member
+    let team_repo = TeamRepository::new(pool.clone());
+    if team_repo
+        .is_member(invitation.team_id, &user_pubkey_hex)
+        .await?
+    {
+        return Err(ApiError::conflict("You are already a member of this team"));
+    }
+
+    // Add to team
+    team_repo
+        .add_member(invitation.team_id, &user_pubkey_hex, &invitation.role)
+        .await?;
+
+    // Mark invitation as accepted
+    invite_repo
+        .accept(&request.token, &user_pubkey_hex)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to mark invitation as accepted: {}", e)))?;
+
+    Ok(Json(AcceptInvitationResponse {
+        team_id: invitation.team_id,
+        role: invitation.role,
+    }))
+}
+
+/// Resolve a pubkey to a display name, falling back to truncated pubkey.
+async fn resolve_display_name(pool: &PgPool, pubkey: &str, tenant_id: i64) -> String {
+    let result: Option<(Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT display_name, username FROM users WHERE pubkey = $1 AND tenant_id = $2",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .fetch_optional(pool)
+    .await
+    .unwrap_or(None);
+
+    match result {
+        Some((Some(display_name), _)) if !display_name.is_empty() => display_name,
+        Some((_, Some(username))) if !username.is_empty() => username,
+        _ => format!("{}…", &pubkey[..8]),
     }
 }

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -32,6 +32,16 @@ pub trait EmailSender: Send + Sync {
     /// Send a claim link email for a preloaded account.
     async fn send_claim_email(&self, to_email: &str, claim_url: &str) -> Result<(), String>;
 
+    /// Send a team invitation email.
+    async fn send_team_invite_email(
+        &self,
+        to_email: &str,
+        team_name: &str,
+        inviter_name: &str,
+        role: &str,
+        invite_url: &str,
+    ) -> Result<(), String>;
+
     /// Get captured emails (only available in dev/test mode)
     fn get_captured_emails(&self) -> Vec<CapturedEmail> {
         vec![]
@@ -146,6 +156,38 @@ fn claim_email_text(claim_url: &str) -> String {
     format!(
         "Your Synvya account is ready. Click this link to claim it:\n\n{}\n\nThis link will expire in 7 days. If you didn't request this, you can safely ignore this email.",
         claim_url
+    )
+}
+
+fn team_invite_html(team_name: &str, inviter_name: &str, role: &str, invite_url: &str) -> String {
+    format!(
+        r#"
+            <html>
+            <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+                <h1 style="color: #00B488;">You're invited to join {team_name}</h1>
+                <p><strong>{inviter_name}</strong> has invited you to join <strong>{team_name}</strong> as a <strong>{role}</strong> on Synvya.</p>
+                <div style="margin: 30px 0;">
+                    <a href="{invite_url}"
+                       style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
+                        Accept Invitation
+                    </a>
+                </div>
+                <p style="color: #666; font-size: 14px;">
+                    Or copy and paste this link into your browser:<br>
+                    <a href="{invite_url}" style="color: #00B488;">{invite_url}</a>
+                </p>
+                <p style="color: #666; font-size: 14px; margin-top: 30px;">
+                    This invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.
+                </p>
+            </body>
+            </html>
+            "#,
+    )
+}
+
+fn team_invite_text(team_name: &str, inviter_name: &str, role: &str, invite_url: &str) -> String {
+    format!(
+        "{inviter_name} has invited you to join {team_name} as a {role} on Synvya.\n\nAccept the invitation:\n{invite_url}\n\nThis invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.",
     )
 }
 
@@ -293,6 +335,44 @@ impl EmailSender for DevEmailSender {
                 to: to_email.to_string(),
                 subject: "Your Synvya account is ready to claim".to_string(),
                 verification_url: Some(claim_url.to_string()),
+                reset_url: None,
+            });
+        }
+
+        Ok(())
+    }
+
+    async fn send_team_invite_email(
+        &self,
+        to_email: &str,
+        team_name: &str,
+        inviter_name: &str,
+        role: &str,
+        invite_url: &str,
+    ) -> Result<(), String> {
+        tracing::info!("");
+        tracing::info!("==================================================");
+        tracing::info!("  TEAM INVITATION EMAIL");
+        tracing::info!("==================================================");
+        tracing::info!("  To: {}", to_email);
+        tracing::info!("  Team: {} (as {})", team_name, role);
+        tracing::info!("  Invited by: {}", inviter_name);
+        tracing::info!("");
+        tracing::info!("  Accept link:");
+        tracing::info!("  {}", invite_url);
+        tracing::info!("==================================================");
+        tracing::info!("");
+
+        eprintln!(
+            "\n\x1b[35m[DEV EMAIL]\x1b[0m Team invite for {} to join {}: \x1b[4m{}\x1b[0m\n",
+            to_email, team_name, invite_url
+        );
+
+        if let Ok(mut captured) = self.captured.lock() {
+            captured.push(CapturedEmail {
+                to: to_email.to_string(),
+                subject: format!("You've been invited to join {} on Synvya", team_name),
+                verification_url: Some(invite_url.to_string()),
                 reset_url: None,
             });
         }
@@ -499,6 +579,21 @@ impl EmailSender for SendGridEmailSender {
 
         self.send_email(to_email, subject, &html, &text).await
     }
+
+    async fn send_team_invite_email(
+        &self,
+        to_email: &str,
+        team_name: &str,
+        inviter_name: &str,
+        role: &str,
+        invite_url: &str,
+    ) -> Result<(), String> {
+        let subject = format!("You've been invited to join {} on Synvya", team_name);
+        let html = team_invite_html(team_name, inviter_name, role, invite_url);
+        let text = team_invite_text(team_name, inviter_name, role, invite_url);
+
+        self.send_email(to_email, &subject, &html, &text).await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -655,6 +750,21 @@ impl EmailSender for SesEmailSender {
 
         self.send_email(to_email, subject, &html, &text).await
     }
+
+    async fn send_team_invite_email(
+        &self,
+        to_email: &str,
+        team_name: &str,
+        inviter_name: &str,
+        role: &str,
+        invite_url: &str,
+    ) -> Result<(), String> {
+        let subject = format!("You've been invited to join {} on Synvya", team_name);
+        let html = team_invite_html(team_name, inviter_name, role, invite_url);
+        let text = team_invite_text(team_name, inviter_name, role, invite_url);
+
+        self.send_email(to_email, &subject, &html, &text).await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -742,5 +852,18 @@ impl EmailService {
 
     pub async fn send_claim_email(&self, to_email: &str, claim_url: &str) -> Result<(), String> {
         self.inner.send_claim_email(to_email, claim_url).await
+    }
+
+    pub async fn send_team_invite_email(
+        &self,
+        to_email: &str,
+        team_name: &str,
+        inviter_name: &str,
+        role: &str,
+        invite_url: &str,
+    ) -> Result<(), String> {
+        self.inner
+            .send_team_invite_email(to_email, team_name, inviter_name, role, invite_url)
+            .await
     }
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,9 +41,10 @@ steps:
         export PGPASSWORD="$$DB_PASS"
 
         # Skip 0001 (initial schema) - it's not idempotent and should only run once
-        # Migrations 0002+ are designed to be safe to re-run
-        for migration in database/migrations/000[2-9]*.sql database/migrations/00[1-9][0-9]*.sql; do
+        # All other migrations (sequential 0002+ and date-based 2026*) are idempotent and safe to re-run
+        for migration in database/migrations/*.sql; do
           [ -f "$$migration" ] || continue
+          [[ "$$(basename $$migration)" == 0001* ]] && continue
           echo "  → $$(basename $$migration)"
           psql -h 127.0.0.1 -U $$DB_USER -d $$DB_NAME -f "$$migration" -q 2>&1 | grep -v "already exists" || true
         done

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -13,6 +13,7 @@ mod refresh_token;
 mod registered_client;
 mod stored_key;
 mod team;
+mod team_invitation;
 mod user;
 
 pub use atproto_oauth_session::{
@@ -32,4 +33,5 @@ pub use refresh_token::RefreshTokenRepository;
 pub use registered_client::RegisteredClientRepository;
 pub use stored_key::StoredKeyRepository;
 pub use team::TeamRepository;
+pub use team_invitation::TeamInvitationRepository;
 pub use user::{AdminUserDetails, DeleteAccountResult, UserRepository, VerificationTokenData};

--- a/core/src/repositories/team_invitation.rs
+++ b/core/src/repositories/team_invitation.rs
@@ -1,0 +1,169 @@
+use chrono::{Duration, Utc};
+use sqlx::PgPool;
+
+use crate::repositories::RepositoryError;
+use crate::types::team_invitation::{TeamInvitation, INVITATION_EXPIRY_DAYS};
+
+/// Repository for team invitation database operations.
+#[derive(Debug, Clone)]
+pub struct TeamInvitationRepository {
+    pool: PgPool,
+}
+
+impl TeamInvitationRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Create a new team invitation.
+    pub async fn create(
+        &self,
+        team_id: i32,
+        tenant_id: i64,
+        email: &str,
+        role: &str,
+        token: &str,
+        invited_by: &str,
+    ) -> Result<TeamInvitation, RepositoryError> {
+        let now = Utc::now();
+        let expires_at = now + Duration::days(INVITATION_EXPIRY_DAYS);
+
+        sqlx::query_as::<_, TeamInvitation>(
+            "INSERT INTO team_invitations
+             (team_id, tenant_id, email, role, token, invited_by, expires_at, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             RETURNING *",
+        )
+        .bind(team_id)
+        .bind(tenant_id)
+        .bind(email)
+        .bind(role)
+        .bind(token)
+        .bind(invited_by)
+        .bind(expires_at)
+        .bind(now)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Find a valid (pending, not expired, not revoked, not accepted) invitation by token.
+    pub async fn find_valid_by_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<TeamInvitation>, RepositoryError> {
+        sqlx::query_as::<_, TeamInvitation>(
+            "SELECT * FROM team_invitations
+             WHERE token = $1
+               AND accepted_at IS NULL
+               AND revoked_at IS NULL
+               AND expires_at > NOW()",
+        )
+        .bind(token)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Find any invitation by token (regardless of status).
+    pub async fn find_by_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<TeamInvitation>, RepositoryError> {
+        sqlx::query_as::<_, TeamInvitation>("SELECT * FROM team_invitations WHERE token = $1")
+            .bind(token)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// List all invitations for a team.
+    pub async fn list_by_team(
+        &self,
+        team_id: i32,
+        tenant_id: i64,
+    ) -> Result<Vec<TeamInvitation>, RepositoryError> {
+        sqlx::query_as::<_, TeamInvitation>(
+            "SELECT * FROM team_invitations
+             WHERE team_id = $1 AND tenant_id = $2
+             ORDER BY created_at DESC",
+        )
+        .bind(team_id)
+        .bind(tenant_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Check if there is already a pending invitation for this email on this team.
+    pub async fn find_pending_by_email(
+        &self,
+        team_id: i32,
+        email: &str,
+    ) -> Result<Option<TeamInvitation>, RepositoryError> {
+        sqlx::query_as::<_, TeamInvitation>(
+            "SELECT * FROM team_invitations
+             WHERE team_id = $1
+               AND email = $2
+               AND accepted_at IS NULL
+               AND revoked_at IS NULL
+               AND expires_at > NOW()",
+        )
+        .bind(team_id)
+        .bind(email)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Mark an invitation as accepted.
+    pub async fn accept(
+        &self,
+        token: &str,
+        accepted_by: &str,
+    ) -> Result<TeamInvitation, RepositoryError> {
+        sqlx::query_as::<_, TeamInvitation>(
+            "UPDATE team_invitations
+             SET accepted_at = NOW(), accepted_by = $1
+             WHERE token = $2
+               AND accepted_at IS NULL
+               AND revoked_at IS NULL
+               AND expires_at > NOW()
+             RETURNING *",
+        )
+        .bind(accepted_by)
+        .bind(token)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Revoke a pending invitation (soft delete via revoked_at).
+    pub async fn revoke(
+        &self,
+        id: i32,
+        team_id: i32,
+        tenant_id: i64,
+    ) -> Result<(), RepositoryError> {
+        let result = sqlx::query(
+            "UPDATE team_invitations
+             SET revoked_at = NOW()
+             WHERE id = $1 AND team_id = $2 AND tenant_id = $3
+               AND accepted_at IS NULL
+               AND revoked_at IS NULL",
+        )
+        .bind(id)
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(RepositoryError::NotFound(
+                "Invitation not found or already resolved".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -6,4 +6,5 @@ pub mod policy;
 pub mod refresh_token;
 pub mod stored_key;
 pub mod team;
+pub mod team_invitation;
 pub mod user;

--- a/core/src/types/team_invitation.rs
+++ b/core/src/types/team_invitation.rs
@@ -1,0 +1,83 @@
+use chrono::{DateTime, Utc};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+/// Invitation expiry in days
+pub const INVITATION_EXPIRY_DAYS: i64 = 7;
+
+/// A pending, accepted, revoked, or expired team invitation
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct TeamInvitation {
+    pub id: i32,
+    pub team_id: i32,
+    pub tenant_id: i64,
+    pub email: String,
+    pub role: String,
+    pub token: String,
+    pub invited_by: String,
+    pub expires_at: DateTime<Utc>,
+    pub accepted_at: Option<DateTime<Utc>>,
+    pub accepted_by: Option<String>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl TeamInvitation {
+    /// Returns true if the invitation is still actionable.
+    pub fn is_pending(&self) -> bool {
+        self.accepted_at.is_none() && self.revoked_at.is_none() && self.expires_at > Utc::now()
+    }
+}
+
+/// Public-facing invitation info returned by the list endpoint
+#[derive(Debug, Serialize)]
+pub struct InvitationListItem {
+    pub id: i32,
+    pub email: String,
+    pub role: String,
+    pub invited_by: String, // resolved to display name
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub accepted_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// Public preview returned to unauthenticated users via token
+#[derive(Debug, Serialize)]
+pub struct InvitationPreview {
+    pub team_name: String,
+    pub role: String,
+    pub invited_by_display_name: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Generate a cryptographically random invitation token (32 bytes, hex-encoded = 64 chars)
+pub fn generate_invitation_token() -> String {
+    let bytes: [u8; 32] = rand::thread_rng().gen();
+    hex::encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_invitation_token_length() {
+        let token = generate_invitation_token();
+        assert_eq!(token.len(), 64);
+    }
+
+    #[test]
+    fn test_generate_invitation_token_uniqueness() {
+        let t1 = generate_invitation_token();
+        let t2 = generate_invitation_token();
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn test_generate_invitation_token_is_hex() {
+        let token = generate_invitation_token();
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/database/migrations/20260413000000_add_team_invitations.sql
+++ b/database/migrations/20260413000000_add_team_invitations.sql
@@ -1,0 +1,28 @@
+-- Team invitations for email-based team member onboarding
+CREATE TABLE team_invitations (
+    id              SERIAL PRIMARY KEY,
+    team_id         INT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    tenant_id       BIGINT NOT NULL,
+    email           VARCHAR(255) NOT NULL,
+    role            VARCHAR(20) NOT NULL DEFAULT 'member',
+    token           VARCHAR(64) NOT NULL UNIQUE,
+    invited_by      VARCHAR(64) NOT NULL,   -- hex pubkey of the admin who sent the invite
+    expires_at      TIMESTAMPTZ NOT NULL,
+    accepted_at     TIMESTAMPTZ,
+    accepted_by     VARCHAR(64),            -- hex pubkey of the user who accepted
+    revoked_at      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT chk_invitation_role CHECK (role IN ('admin', 'member'))
+);
+
+-- Fast token lookup
+CREATE INDEX idx_team_invitations_token ON team_invitations(token);
+
+-- List invitations for a team
+CREATE INDEX idx_team_invitations_team ON team_invitations(team_id);
+
+-- Prevent duplicate pending invitations for the same email on the same team
+CREATE UNIQUE INDEX uq_pending_invite
+    ON team_invitations(team_id, email)
+    WHERE accepted_at IS NULL AND revoked_at IS NULL;

--- a/docs/synvya/team-invite-by-email.md
+++ b/docs/synvya/team-invite-by-email.md
@@ -1,0 +1,304 @@
+# Team Invite by Email
+
+Spec for email-based team invitations in Keycast. Adds a `team_invitations` table, an invite endpoint that sends email to new users (or instantly adds existing users), and an accept flow that converts a token into team membership.
+
+**Issue**: [Synvya/client#365](https://github.com/Synvya/client/issues/365)
+
+**System context**:
+- [Keycast Boundary](keycast-boundary.md)
+- [Cross-repo: Team Invite by Email](https://github.com/Synvya/docs/blob/main/architecture/team-invite-by-email.md) — sequence diagrams and contract between repos
+
+---
+
+## 1. Scope
+
+Keycast already owns team membership (`POST /teams/:id/users`). This feature extends that ownership to include invitation lifecycle: creation, email delivery, preview, acceptance, revocation, and expiry.
+
+### What Keycast owns (new)
+- `team_invitations` table and all CRUD
+- Email delivery of invitation links
+- Token validation and acceptance (resolving token → team membership)
+- Invitation preview for unauthenticated users (enough to render a landing page)
+
+### What Keycast does NOT own
+- The invitation landing page UI (that's the client)
+- Deciding where the invite link points (client provides the base URL, or it's derived from the tenant's configured redirect origin)
+
+## 2. Data Model
+
+### 2.1 New Table: `team_invitations`
+
+```sql
+CREATE TABLE team_invitations (
+    id              SERIAL PRIMARY KEY,
+    team_id         INT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    tenant_id       BIGINT NOT NULL,
+    email           VARCHAR(255) NOT NULL,
+    role            VARCHAR(20) NOT NULL DEFAULT 'Member',
+    token           VARCHAR(64) NOT NULL UNIQUE,
+    invited_by      VARCHAR(64) NOT NULL,   -- hex pubkey of the admin who sent the invite
+    expires_at      TIMESTAMPTZ NOT NULL,
+    accepted_at     TIMESTAMPTZ,
+    accepted_by     VARCHAR(64),            -- hex pubkey of the user who accepted
+    revoked_at      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Prevent duplicate pending invitations for the same email on the same team
+    CONSTRAINT uq_pending_invite UNIQUE (team_id, email)
+        -- NOTE: partial unique index preferred (WHERE accepted_at IS NULL AND revoked_at IS NULL)
+        -- but standard UNIQUE constraint is simpler; enforce in application code if needed.
+);
+
+CREATE INDEX idx_team_invitations_token ON team_invitations(token);
+CREATE INDEX idx_team_invitations_team ON team_invitations(team_id);
+```
+
+Token generation: 32 random bytes, hex-encoded (64 chars). Use the same `generate_claim_token` pattern from `keycast_core::types::claim_token`.
+
+Invitation expiry: **7 days** from creation.
+
+### 2.2 Rust Types
+
+```rust
+// keycast_core/src/types/team_invitation.rs
+
+pub struct TeamInvitation {
+    pub id: i32,
+    pub team_id: i32,
+    pub tenant_id: i64,
+    pub email: String,
+    pub role: String,
+    pub token: String,
+    pub invited_by: String,
+    pub expires_at: DateTime<Utc>,
+    pub accepted_at: Option<DateTime<Utc>>,
+    pub accepted_by: Option<String>,
+    pub revoked_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl TeamInvitation {
+    pub fn is_pending(&self) -> bool {
+        self.accepted_at.is_none()
+            && self.revoked_at.is_none()
+            && self.expires_at > Utc::now()
+    }
+}
+```
+
+### 2.3 Repository
+
+```rust
+// keycast_core/src/repositories/team_invitation.rs
+
+pub struct TeamInvitationRepository { pool: PgPool }
+
+impl TeamInvitationRepository {
+    pub async fn create(...) -> Result<TeamInvitation>;
+    pub async fn find_by_token(token: &str) -> Result<Option<TeamInvitation>>;
+    pub async fn find_valid_by_token(token: &str) -> Result<Option<TeamInvitation>>;
+    pub async fn list_by_team(team_id: i32, tenant_id: i64) -> Result<Vec<TeamInvitation>>;
+    pub async fn find_pending_by_email(team_id: i32, email: &str) -> Result<Option<TeamInvitation>>;
+    pub async fn accept(token: &str, accepted_by: &str) -> Result<()>;
+    pub async fn revoke(id: i32, team_id: i32, tenant_id: i64) -> Result<()>;
+}
+```
+
+`find_valid_by_token` returns `Some` only if `accepted_at IS NULL AND revoked_at IS NULL AND expires_at > NOW()`.
+
+## 3. Endpoints
+
+### 3.1 `POST /api/teams/:id/invite`
+
+**Auth**: UCAN session (requires team admin).
+
+**Request**:
+```json
+{ "email": "manager@restaurant.com", "role": "Member" }
+```
+
+**Logic**:
+
+```
+1. Verify caller is admin of team :id
+2. Normalize email (lowercase, trim)
+3. Validate email format
+4. Check if email belongs to the calling user → 400 "Cannot invite yourself"
+5. Look up user by email in this tenant:
+   a. User exists:
+      - Check if already a team member → 409 "Already a team member"
+      - Add to team via TeamRepository::add_member
+      - Return { status: "added", member: { ... } }
+   b. User does not exist:
+      - Check for existing pending invitation for this email+team → 409 "Invitation already pending"
+      - Generate token (32 random bytes, hex)
+      - Insert into team_invitations
+      - Build invite URL: {client_origin}/accept-invite?token={token}
+      - Send invitation email via EmailSender::send_team_invite_email
+      - Return { status: "invited", invitation: { ... } }
+```
+
+**Response codes**: 200 (success), 400 (bad input), 409 (conflict), 403 (not admin).
+
+### 3.2 `GET /api/teams/:id/invitations`
+
+**Auth**: UCAN session (requires team admin).
+
+Returns all invitations for the team (pending, accepted, revoked, expired). Client filters as needed.
+
+**Response**:
+```json
+[
+  {
+    "id": 42,
+    "email": "manager@restaurant.com",
+    "role": "Member",
+    "invited_by": "Alejandro",
+    "created_at": "2026-04-12T...",
+    "expires_at": "2026-04-19T...",
+    "accepted_at": null,
+    "revoked_at": null
+  }
+]
+```
+
+The `invited_by` field is resolved to a display name (from `user_profiles`) for the response. Falls back to truncated pubkey if no profile exists.
+
+### 3.3 `DELETE /api/teams/:id/invitations/:invitation_id`
+
+**Auth**: UCAN session (requires team admin).
+
+Sets `revoked_at = NOW()` on the invitation. Only works if the invitation is still pending (not yet accepted, not yet revoked, not expired).
+
+**Response**: 204 No Content.
+
+### 3.4 `GET /api/invitations/preview?token=...`
+
+**Auth**: None (public endpoint).
+
+Returns enough data for the client to render the invite landing page without authentication.
+
+**Response**:
+```json
+{
+  "team_name": "Taqueria La Estrella",
+  "role": "Member",
+  "invited_by_display_name": "Alejandro",
+  "expires_at": "2026-04-19T..."
+}
+```
+
+Returns 404 if the token is invalid, expired, accepted, or revoked. The response intentionally omits the token itself (it's in the query string already) and the email (privacy — the link holder may not be the intended recipient).
+
+**Security**: This endpoint leaks the team name and inviter name to anyone with the token. Since tokens are 256-bit random, this is acceptable. The token URL is only sent via email.
+
+### 3.5 `POST /api/invitations/accept`
+
+**Auth**: UCAN session (authenticated user).
+
+**Request**:
+```json
+{ "token": "abc123..." }
+```
+
+**Logic**:
+```
+1. Validate token → find_valid_by_token
+2. Token not found or not pending → 404 / 410 Gone
+3. Get authenticated user's email from session
+4. Compare with invitation email (case-insensitive) → 403 if mismatch
+5. Check if user is already a team member → 409
+6. Add user to team with invitation's role
+7. Mark invitation as accepted (accepted_at = NOW(), accepted_by = user pubkey)
+8. Return { team_id, role }
+```
+
+**Response codes**: 200 (success), 403 (email mismatch), 404 (invalid token), 409 (already member), 410 (expired).
+
+## 4. Email
+
+### 4.1 EmailSender Trait Extension
+
+Add to the existing `EmailSender` trait:
+
+```rust
+async fn send_team_invite_email(
+    &self,
+    to_email: &str,
+    team_name: &str,
+    inviter_name: &str,
+    role: &str,
+    invite_url: &str,
+) -> Result<(), String>;
+```
+
+### 4.2 Email Content
+
+**Subject**: "You've been invited to join {team_name} on Synvya"
+
+**Body** (key elements):
+- "{inviter_name} has invited you to join **{team_name}** as a **{role}**."
+- CTA button: "Accept Invitation" → `{invite_url}`
+- Footer: "This invitation expires in 7 days. If you didn't expect this email, you can safely ignore it."
+
+Use the same HTML email template style as existing verification and password-reset emails.
+
+### 4.3 Invite URL Construction
+
+The invite URL must point to the client app, not to a Keycast-hosted page. Derive the base URL from the tenant's configured redirect origin or from a new `INVITE_BASE_URL` env var:
+
+```
+{INVITE_BASE_URL}/accept-invite?token={token}
+```
+
+For the Synvya tenant: `https://account.synvya.com/accept-invite?token=...`
+For staging: `https://account.staging.synvya.com/accept-invite?token=...`
+
+## 5. CORS
+
+- `POST /teams/:id/invite`, `GET /teams/:id/invitations`, `DELETE /teams/:id/invitations/:id` — same CORS as existing team routes (first-party `auth_cors`).
+- `GET /invitations/preview` — public CORS (no auth, called from client before login).
+- `POST /invitations/accept` — first-party `auth_cors` (requires session cookie).
+
+## 6. Routing
+
+Add to `routes.rs`:
+
+```rust
+// Under team_routes (existing, auth_cors):
+.route("/teams/:id/invite", post(teams::invite_user))
+.route("/teams/:id/invitations", get(teams::list_invitations))
+.route("/teams/:id/invitations/:invitation_id", delete(teams::revoke_invitation))
+
+// New invitation routes (mixed auth):
+let invitation_routes = Router::new()
+    .route("/invitations/preview", get(teams::preview_invitation))  // public
+    .route("/invitations/accept", post(teams::accept_invitation))   // auth required
+    .with_state(auth_state.clone());
+```
+
+## 7. Security Considerations
+
+| Concern | Mitigation |
+|---|---|
+| Token brute-force | 256-bit random tokens (64 hex chars). Rate-limit preview/accept endpoints |
+| Email enumeration via invite | The `invite` endpoint requires admin auth. The response distinguishes "added" vs "invited" only to the admin, which is acceptable since the admin already knows their team members |
+| Preview leaks team name | Acceptable given token entropy. No PII beyond team name and inviter display name |
+| Invitation to wrong person | Accept endpoint verifies authenticated user's email matches invitation email |
+| Replay after acceptance | `accepted_at` is set; `find_valid_by_token` excludes accepted tokens |
+
+## 8. Relationship to Existing Endpoints
+
+- `POST /teams/:id/users` (add by pubkey) **remains unchanged**. It continues to work for programmatic/admin use. The new `invite` endpoint calls the same `TeamRepository::add_member` internally when the user already exists.
+- The claim-token system (`/claim`, `/admin/claim-tokens`) is separate — it's for Vine-imported preloaded accounts, not team invitations.
+- The `EmailSender` trait gains one new method; existing email types are untouched.
+
+## 9. Implementation Order
+
+1. Migration: create `team_invitations` table
+2. Core: `TeamInvitation` type + `TeamInvitationRepository`
+3. Email: `send_team_invite_email` on `EmailSender` trait + implementations (SendGrid, SES, Dev)
+4. API: `POST /teams/:id/invite` (both paths)
+5. API: `GET /teams/:id/invitations`, `DELETE /teams/:id/invitations/:id`
+6. API: `GET /invitations/preview`, `POST /invitations/accept`
+7. Tests: unit tests for repository, integration tests for invite + accept flow


### PR DESCRIPTION
## Summary
- Adds email-based team invitations: admins invite by email, existing users are added instantly, new users receive an invitation email with a 7-day token
- Five new endpoints: invite, list, revoke, preview (public), accept (authenticated)
- Adds `team_invitations` table with partial unique index for pending invites
- Adds `send_team_invite_email` to all email providers (SendGrid, SES, Dev)
- Fixes `cloudbuild.yaml` migration glob to pick up date-based filenames

## Test plan
- [ ] Run migration locally: `psql -f database/migrations/20260413000000_add_team_invitations.sql`
- [ ] Test invite existing user (instant add) via `POST /teams/:id/invite`
- [ ] Test invite new user (email sent) via `POST /teams/:id/invite`
- [ ] Test preview endpoint returns team name and role without auth
- [ ] Test accept endpoint verifies email match and adds to team
- [ ] Test revoke sets `revoked_at` and blocks subsequent accept
- [ ] Test duplicate invite returns 409
- [ ] Verify `cargo check`, `cargo fmt`, `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)