### PR TITLE
Apply cargo fmt to admin get_user_teams handler

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -973,9 +973,7 @@ pub async fn get_user_teams(
 
     let pubkey = query.pubkey.trim().to_lowercase();
     if pubkey.len() != 64 || !pubkey.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(ApiError::bad_request(
-            "pubkey must be a 64-char hex string",
-        ));
+        return Err(ApiError::bad_request("pubkey must be a 64-char hex string"));
     }
 
     // Teams the user belongs to (tenant-scoped)
@@ -1027,8 +1025,7 @@ pub async fn get_user_teams(
             let authorizations = auth_rows
                 .into_iter()
                 .map(|row| {
-                    let relays: Vec<String> =
-                        serde_json::from_str(&row.relays).unwrap_or_default();
+                    let relays: Vec<String> = serde_json::from_str(&row.relays).unwrap_or_default();
                     AdminAuthorization {
                         id: row.id,
                         label: row.label,


### PR DESCRIPTION
## Summary
- CI `cargo fmt --all -- --check` failed on two formatting issues in `get_user_teams` (added in #15, refactored in #16).
- Applies `cargo fmt` — collapses the `ApiError::bad_request` call and the `relays` let-binding to single lines.

## Test plan
- [x] `cargo fmt --all -- --check` passes locally
- [ ] CI fmt job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)