### PR TITLE
feat: soft-delete for team authorizations (#18)

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -1062,6 +1062,92 @@ pub async fn get_user_teams(
 }
 
 // ============================================================================
+// POST /api/admin/authorizations/:id/revoke - Soft-delete a team authorization
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct RevokeAuthorizationRequest {
+    /// Optional free-text reason (e.g. "superseded", "admin_revoke", "client_revoke").
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RevokeAuthorizationResponse {
+    pub revoked: bool,
+    pub authorization_id: i32,
+}
+
+/// Soft-delete a team authorization by setting `revoked_at = NOW()` and
+/// notifying the signer daemon so it drops the in-memory handler.
+/// Support admin only; tenant-scoped.
+pub async fn revoke_authorization(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Path(authorization_id): Path<i32>,
+    Json(req): Json<RevokeAuthorizationRequest>,
+) -> ApiResult<Json<RevokeAuthorizationResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+
+    let reason = req
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    let repo = keycast_core::repositories::AuthorizationRepository::new(pool.clone());
+    let bunker_pubkey = repo
+        .revoke(tenant_id, authorization_id, reason)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to revoke authorization: {}", e)))?;
+
+    let Some(bunker_pubkey) = bunker_pubkey else {
+        // Either not found in this tenant, or already revoked.
+        return Err(ApiError::not_found(
+            "Authorization not found or already revoked",
+        ));
+    };
+
+    // Notify the signer daemon to drop the in-memory handler. If the channel
+    // send fails, the DB write still stands; a daemon restart will pick up the
+    // revoked state on next lazy load.
+    if let Some(tx) = &auth_state.auth_tx {
+        use keycast_core::authorization_channel::AuthorizationCommand;
+        if let Err(e) = tx
+            .send(AuthorizationCommand::Remove {
+                bunker_pubkey: bunker_pubkey.clone(),
+            })
+            .await
+        {
+            tracing::warn!(
+                "Failed to notify signer of revocation for {}: {}",
+                bunker_pubkey,
+                e
+            );
+        }
+    }
+
+    tracing::info!(
+        "Authorization {} revoked by admin {} (tenant {}, reason: {:?})",
+        authorization_id,
+        &auth.pubkey[..8.min(auth.pubkey.len())],
+        tenant_id,
+        reason,
+    );
+
+    Ok(Json(RevokeAuthorizationResponse {
+        revoked: true,
+        authorization_id,
+    }))
+}
+
+// ============================================================================
 // Support Admin Management (Redis-backed)
 // ============================================================================
 

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -199,6 +199,10 @@ pub fn api_routes(
         .route("/admin/user-lookup", get(admin::get_user_lookup))
         .route("/admin/user-teams", get(admin::get_user_teams))
         .route(
+            "/admin/authorizations/:id/revoke",
+            post(admin::revoke_authorization),
+        )
+        .route(
             "/admin/support-admins",
             get(admin::list_support_admins).post(admin::add_support_admin),
         )

--- a/core/src/repositories/authorization.rs
+++ b/core/src/repositories/authorization.rs
@@ -17,7 +17,8 @@ impl AuthorizationRepository {
         Self { pool }
     }
 
-    /// Find an authorization by ID.
+    /// Find an authorization by ID (includes revoked rows — callers that need to
+    /// exclude revoked should check `revoked_at`).
     pub async fn find(
         &self,
         tenant_id: i64,
@@ -26,7 +27,8 @@ impl AuthorizationRepository {
         sqlx::query_as::<_, Authorization>(
             "SELECT id, tenant_id, stored_key_id, secret_hash, bunker_public_key,
                     relays, policy_id, max_uses, expires_at, connected_client_pubkey,
-                    connected_at, label, created_at, updated_at
+                    connected_at, label, created_at, updated_at,
+                    revoked_at, revoked_reason
              FROM authorizations WHERE tenant_id = $1 AND id = $2",
         )
         .bind(tenant_id)
@@ -36,40 +38,97 @@ impl AuthorizationRepository {
         .map_err(Into::into)
     }
 
-    /// Find all authorizations for a stored key.
+    /// Find active authorizations for a stored key (excludes revoked rows).
     pub async fn find_by_stored_key(
         &self,
         tenant_id: i64,
         stored_key_id: i32,
     ) -> Result<Vec<Authorization>, RepositoryError> {
-        sqlx::query_as::<_, Authorization>(
-            "SELECT id, tenant_id, stored_key_id, secret_hash, bunker_public_key,
+        self.find_by_stored_key_inner(tenant_id, stored_key_id, false)
+            .await
+    }
+
+    /// Find authorizations for a stored key, optionally including revoked rows
+    /// (for admin views that need to surface soft-deleted history).
+    pub async fn find_by_stored_key_with_revoked(
+        &self,
+        tenant_id: i64,
+        stored_key_id: i32,
+        include_revoked: bool,
+    ) -> Result<Vec<Authorization>, RepositoryError> {
+        self.find_by_stored_key_inner(tenant_id, stored_key_id, include_revoked)
+            .await
+    }
+
+    async fn find_by_stored_key_inner(
+        &self,
+        tenant_id: i64,
+        stored_key_id: i32,
+        include_revoked: bool,
+    ) -> Result<Vec<Authorization>, RepositoryError> {
+        let base = "SELECT id, tenant_id, stored_key_id, secret_hash, bunker_public_key,
                     relays, policy_id, max_uses, expires_at, connected_client_pubkey,
-                    connected_at, label, created_at, updated_at
-             FROM authorizations WHERE tenant_id = $1 AND stored_key_id = $2",
+                    connected_at, label, created_at, updated_at,
+                    revoked_at, revoked_reason
+             FROM authorizations WHERE tenant_id = $1 AND stored_key_id = $2";
+        let sql = if include_revoked {
+            base.to_string()
+        } else {
+            format!("{} AND revoked_at IS NULL", base)
+        };
+        sqlx::query_as::<_, Authorization>(&sql)
+            .bind(tenant_id)
+            .bind(stored_key_id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Get all active authorization IDs for a tenant (excludes revoked rows).
+    pub async fn all_ids(&self, tenant_id: i64) -> Result<Vec<i32>, RepositoryError> {
+        sqlx::query_scalar::<_, i32>(
+            "SELECT id FROM authorizations WHERE tenant_id = $1 AND revoked_at IS NULL",
         )
         .bind(tenant_id)
-        .bind(stored_key_id)
         .fetch_all(&self.pool)
         .await
         .map_err(Into::into)
     }
 
-    /// Get all authorization IDs for a tenant.
-    pub async fn all_ids(&self, tenant_id: i64) -> Result<Vec<i32>, RepositoryError> {
-        sqlx::query_scalar::<_, i32>("SELECT id FROM authorizations WHERE tenant_id = $1")
-            .bind(tenant_id)
-            .fetch_all(&self.pool)
-            .await
-            .map_err(Into::into)
+    /// Get all active authorization IDs for all tenants (excludes revoked rows).
+    pub async fn all_ids_for_all_tenants(&self) -> Result<Vec<(i64, i32)>, RepositoryError> {
+        sqlx::query_as::<_, (i64, i32)>(
+            "SELECT tenant_id, id FROM authorizations WHERE revoked_at IS NULL",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
     }
 
-    /// Get all authorization IDs for all tenants.
-    pub async fn all_ids_for_all_tenants(&self) -> Result<Vec<(i64, i32)>, RepositoryError> {
-        sqlx::query_as::<_, (i64, i32)>("SELECT tenant_id, id FROM authorizations")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(Into::into)
+    /// Soft-delete an authorization by setting `revoked_at = NOW()`.
+    /// Returns the bunker_public_key of the revoked row (used by the caller to
+    /// notify the signer daemon via the authorization channel), or `None` if
+    /// the authorization didn't exist or was already revoked.
+    pub async fn revoke(
+        &self,
+        tenant_id: i64,
+        authorization_id: i32,
+        reason: Option<&str>,
+    ) -> Result<Option<String>, RepositoryError> {
+        let bunker_pubkey: Option<String> = sqlx::query_scalar(
+            "UPDATE authorizations
+             SET revoked_at = NOW(),
+                 revoked_reason = $3,
+                 updated_at = NOW()
+             WHERE tenant_id = $1 AND id = $2 AND revoked_at IS NULL
+             RETURNING bunker_public_key",
+        )
+        .bind(tenant_id)
+        .bind(authorization_id)
+        .bind(reason)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(bunker_pubkey)
     }
 
     /// Create a new authorization.
@@ -92,7 +151,7 @@ impl AuthorizationRepository {
         sqlx::query_as::<_, Authorization>(
             "INSERT INTO authorizations (tenant_id, stored_key_id, policy_id, secret_hash, bunker_public_key, relays, max_uses, expires_at, label, created_at, updated_at)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
-             RETURNING id, tenant_id, stored_key_id, secret_hash, bunker_public_key, relays, policy_id, max_uses, expires_at, connected_client_pubkey, connected_at, label, created_at, updated_at",
+             RETURNING id, tenant_id, stored_key_id, secret_hash, bunker_public_key, relays, policy_id, max_uses, expires_at, connected_client_pubkey, connected_at, label, created_at, updated_at, revoked_at, revoked_reason",
         )
         .bind(tenant_id)
         .bind(stored_key_id)

--- a/core/src/types/authorization.rs
+++ b/core/src/types/authorization.rs
@@ -89,6 +89,10 @@ pub struct Authorization {
     pub created_at: DateTime<chrono::Utc>,
     /// The date and time the authorization was last updated
     pub updated_at: DateTime<chrono::Utc>,
+    /// When this authorization was soft-deleted (NULL = active).
+    pub revoked_at: Option<DateTime<chrono::Utc>>,
+    /// Optional free-text reason for revocation (e.g. "superseded", "admin_revoke").
+    pub revoked_reason: Option<String>,
 }
 
 #[derive(Debug, FromRow, Serialize, Deserialize)]
@@ -107,7 +111,8 @@ impl Authorization {
         let authorization = sqlx::query_as::<_, Authorization>(
             "SELECT id, tenant_id, stored_key_id, secret_hash, bunker_public_key,
                     relays, policy_id, max_uses, expires_at, connected_client_pubkey,
-                    connected_at, label, created_at, updated_at
+                    connected_at, label, created_at, updated_at,
+                    revoked_at, revoked_reason
              FROM authorizations WHERE tenant_id = $1 AND id = $2",
         )
         .bind(tenant_id)
@@ -120,7 +125,7 @@ impl Authorization {
     pub async fn all_ids(pool: &PgPool, tenant_id: i64) -> Result<Vec<i32>, AuthorizationError> {
         let authorizations = sqlx::query_scalar::<_, i32>(
             r#"
-            SELECT id FROM authorizations WHERE tenant_id = $1
+            SELECT id FROM authorizations WHERE tenant_id = $1 AND revoked_at IS NULL
             "#,
         )
         .bind(tenant_id)
@@ -134,7 +139,7 @@ impl Authorization {
     ) -> Result<Vec<(i64, i32)>, AuthorizationError> {
         let authorizations = sqlx::query_as::<_, (i64, i32)>(
             r#"
-            SELECT tenant_id, id FROM authorizations
+            SELECT tenant_id, id FROM authorizations WHERE revoked_at IS NULL
             "#,
         )
         .fetch_all(pool)

--- a/database/migrations/20260413120000_add_revoked_at_to_authorizations.sql
+++ b/database/migrations/20260413120000_add_revoked_at_to_authorizations.sql
@@ -1,0 +1,14 @@
+-- Add soft-delete columns to team authorizations.
+-- Mirrors oauth_authorizations.revoked_at so the signer daemon can skip stale
+-- team authorizations (e.g. duplicate "Synvya Client (staging)" rows) without
+-- hard-deleting and losing forensic history.
+
+ALTER TABLE authorizations
+    ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS revoked_reason TEXT;
+
+-- Partial index to speed up the "active authorizations" lookup used by the
+-- signer daemon and repository methods.
+CREATE INDEX IF NOT EXISTS idx_authorizations_active
+    ON authorizations (tenant_id, bunker_public_key)
+    WHERE revoked_at IS NULL;

--- a/signer/src/signer_daemon.rs
+++ b/signer/src/signer_daemon.rs
@@ -850,7 +850,8 @@ impl UnifiedSigner {
             // Load regular authorization
             let auth_data: Option<(i32, String, i64)> = sqlx::query_as(
                 "SELECT id, secret_hash, stored_key_id FROM authorizations
-                 WHERE tenant_id = $1 AND bunker_public_key = $2",
+                 WHERE tenant_id = $1 AND bunker_public_key = $2
+                   AND revoked_at IS NULL",
             )
             .bind(tenant_id)
             .bind(bunker_pubkey)


### PR DESCRIPTION
## Summary
- Adds `revoked_at` + `revoked_reason` to the `authorizations` table (mirrors the existing `oauth_authorizations` soft-delete pattern).
- Signer daemon skips revoked team rows on lazy load; existing `AuthorizationCommand::Remove` channel tombstones in-memory handlers.
- New support-admin endpoint `POST /api/admin/authorizations/:id/revoke` (tenant-scoped) lets us mark stale rows inactive without hard-deleting and losing forensic history.

Motivates: Synvya restaurants accumulating duplicate `Synvya Client (staging)` / `Synvya Server (staging)` authorization rows (see PR #15 discussion). Even once the client-side dedupe lands, Keycast needed a way to retire existing stale rows.

## Changes
- **Migration** `20260413120000_add_revoked_at_to_authorizations.sql` — idempotent `IF NOT EXISTS`; adds partial index on active rows.
- **`Authorization` struct** — new `revoked_at` + `revoked_reason` fields; `Authorization::all_ids*` helpers filter to active rows.
- **`AuthorizationRepository`** — `find_by_stored_key` filters revoked by default; new `find_by_stored_key_with_revoked` for admin views; new `revoke(tenant_id, id, reason)` returns the revoked row's bunker_pubkey for channel notification.
- **Signer daemon** — `load_single_authorization` team path now filters `WHERE revoked_at IS NULL` (OAuth path already did).
- **Admin endpoint** — `POST /api/admin/authorizations/:id/revoke`, support-admin gated, body `{ reason?: string }`. Sends `AuthorizationCommand::Remove` so signer drops handler immediately.

## Out of scope
- Support-admin UI wiring (Revoke button + show/hide toggle) — follow-up.
- Repository integration tests for revoke/filter behavior — follow-up; existing tests in this file are `feature = "integration-tests"` gated and require a local Postgres.
- Automatic revoke-on-create-with-same-label (dedupe-on-create) — intentionally out of scope per the issue; primary prevention belongs in the Synvya client.

## Test plan
- [x] `cargo build --workspace` passes locally
- [x] `cargo clippy --workspace --no-deps -- -D warnings` passes locally
- [ ] Apply migration in staging DB
- [ ] Manually revoke a test authorization via the new endpoint; confirm signer drops the handler and NIP-46 connect fails
- [ ] Confirm non-admin caller gets 403; cross-tenant revoke returns 404

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)