### PR TITLE
feat(support-admin): collapse same-label authorizations (#19)

### DIFF
--- a/web/src/routes/support-admin/+page.svelte
+++ b/web/src/routes/support-admin/+page.svelte
@@ -237,6 +237,67 @@
 		return !!label && /synvya\s+client/i.test(label);
 	}
 
+	interface AuthGroup {
+		key: string; // group key for UI (`(no label)` for empty labels)
+		label: string | null;
+		displayLabel: string;
+		serverAuth: boolean;
+		clientAuth: boolean;
+		authorizations: AdminAuthorization[]; // newest-first
+	}
+
+	/** Group authorizations by label, newest-first within each group. */
+	function groupAuthorizations(auths: AdminAuthorization[]): AuthGroup[] {
+		const groups = new Map<string, AuthGroup>();
+		for (const a of auths) {
+			const labelNorm = a.label && a.label.trim() ? a.label.trim() : '';
+			const key = labelNorm || '(no label)';
+			let group = groups.get(key);
+			if (!group) {
+				group = {
+					key,
+					label: labelNorm || null,
+					displayLabel: labelNorm || '(no label)',
+					serverAuth: isSynvyaServerAuth(labelNorm || null),
+					clientAuth: isSynvyaClientAuth(labelNorm || null),
+					authorizations: [],
+				};
+				groups.set(key, group);
+			}
+			group.authorizations.push(a);
+		}
+		for (const group of groups.values()) {
+			group.authorizations.sort(
+				(x, y) => new Date(y.created_at).getTime() - new Date(x.created_at).getTime(),
+			);
+		}
+		// Order groups by the most recent authorization within each group (newest first).
+		return Array.from(groups.values()).sort(
+			(a, b) =>
+				new Date(b.authorizations[0].created_at).getTime() -
+				new Date(a.authorizations[0].created_at).getTime(),
+		);
+	}
+
+	// Per-group expand/collapse for older authorizations in the Synvya admin view.
+	// Keyed by `${restaurantKeyId}|${groupKey}`; presence = expanded.
+	let expandedAuthGroups = $state<Set<string>>(new Set());
+
+	function authGroupExpandKey(keyId: number, groupKey: string): string {
+		return `${keyId}|${groupKey}`;
+	}
+
+	function toggleAuthGroup(keyId: number, groupKey: string) {
+		const k = authGroupExpandKey(keyId, groupKey);
+		const next = new Set(expandedAuthGroups);
+		if (next.has(k)) {
+			next.delete(k);
+		} else {
+			next.add(k);
+		}
+		expandedAuthGroups = next;
+	}
+
 	$effect(() => {
 		if (expandedPubkey && searchResult) {
 			const user = searchResult.results.find(u => u.pubkey === expandedPubkey);
@@ -517,6 +578,94 @@
 
 																			{#if key.authorizations.length === 0}
 																				<p class="muted-text indent">No authorizations on this key.</p>
+																			{:else if isSynvyaManaged}
+																				<div class="auth-list">
+																					{#each groupAuthorizations(key.authorizations) as group (group.key)}
+																						{@const expanded = expandedAuthGroups.has(authGroupExpandKey(key.id, group.key))}
+																						{@const newest = group.authorizations[0]}
+																						{@const olderCount = group.authorizations.length - 1}
+																						<div class="auth-group" class:auth-server={group.serverAuth} class:auth-client={group.clientAuth}>
+																							<div class="auth-group-header">
+																								<span class="auth-label">{group.displayLabel}</span>
+																								<span class="auth-count-badge">· {group.authorizations.length}</span>
+																								{#if group.serverAuth}
+																									<span class="pill pill-server">24/7</span>
+																								{:else if group.clientAuth}
+																									<span class="pill pill-client">interactive</span>
+																								{/if}
+																							</div>
+																							<div class="auth-card auth-card-plain">
+																								<div class="auth-card-header">
+																									<span class="auth-sub-label">Authorization #{newest.id} <span class="muted-text">· newest</span></span>
+																								</div>
+																								<div class="auth-meta">
+																									<div class="auth-meta-row">
+																										<span class="auth-meta-label">Bunker</span>
+																										<span class="mono auth-meta-value" title={newest.bunker_public_key}>{truncateFormatted(newest.bunker_public_key)}</span>
+																									</div>
+																									<div class="auth-meta-row">
+																										<span class="auth-meta-label">Created</span>
+																										<span class="auth-meta-value">{formatDate(newest.created_at)}</span>
+																									</div>
+																									<div class="auth-meta-row">
+																										<span class="auth-meta-label">Connected</span>
+																										<span class="auth-meta-value">{newest.connected_at ? formatDate(newest.connected_at) : '—'}</span>
+																									</div>
+																									<div class="auth-meta-row">
+																										<span class="auth-meta-label">Expires</span>
+																										<span class="auth-meta-value">{newest.expires_at ? formatDate(newest.expires_at) : 'Never'}</span>
+																									</div>
+																									<div class="auth-meta-row">
+																										<span class="auth-meta-label">Relays</span>
+																										<span class="auth-meta-value relays">{newest.relays.length === 0 ? '—' : newest.relays.join(', ')}</span>
+																									</div>
+																								</div>
+																							</div>
+																							{#if olderCount > 0}
+																								<button type="button" class="auth-older-toggle" onclick={() => toggleAuthGroup(key.id, group.key)}>
+																									{#if expanded}
+																										<CaretDown size={14} /> Hide {olderCount} older
+																									{:else}
+																										<CaretRight size={14} /> {olderCount} older {group.displayLabel} authorization{olderCount === 1 ? '' : 's'}
+																									{/if}
+																								</button>
+																								{#if expanded}
+																									<div class="auth-older-list">
+																										{#each group.authorizations.slice(1) as a (a.id)}
+																											<div class="auth-card auth-card-plain auth-card-older">
+																												<div class="auth-card-header">
+																													<span class="auth-sub-label">Authorization #{a.id}</span>
+																												</div>
+																												<div class="auth-meta">
+																													<div class="auth-meta-row">
+																														<span class="auth-meta-label">Bunker</span>
+																														<span class="mono auth-meta-value" title={a.bunker_public_key}>{truncateFormatted(a.bunker_public_key)}</span>
+																													</div>
+																													<div class="auth-meta-row">
+																														<span class="auth-meta-label">Created</span>
+																														<span class="auth-meta-value">{formatDate(a.created_at)}</span>
+																													</div>
+																													<div class="auth-meta-row">
+																														<span class="auth-meta-label">Connected</span>
+																														<span class="auth-meta-value">{a.connected_at ? formatDate(a.connected_at) : '—'}</span>
+																													</div>
+																													<div class="auth-meta-row">
+																														<span class="auth-meta-label">Expires</span>
+																														<span class="auth-meta-value">{a.expires_at ? formatDate(a.expires_at) : 'Never'}</span>
+																													</div>
+																													<div class="auth-meta-row">
+																														<span class="auth-meta-label">Relays</span>
+																														<span class="auth-meta-value relays">{a.relays.length === 0 ? '—' : a.relays.join(', ')}</span>
+																													</div>
+																												</div>
+																											</div>
+																										{/each}
+																									</div>
+																								{/if}
+																							{/if}
+																						</div>
+																					{/each}
+																				</div>
 																			{:else}
 																				<div class="auth-list">
 																					{#each key.authorizations as a (a.id)}
@@ -1266,6 +1415,83 @@
 
 	.auth-card.auth-client {
 		border-left: 3px solid #3b82f6;
+	}
+
+	/* Grouped authorizations (Synvya admin view) */
+	.auth-group {
+		border: 1px solid var(--color-divine-border);
+		border-radius: 8px;
+		background: var(--color-divine-bg);
+		padding: 0.5rem 0.625rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.auth-group.auth-server {
+		border-left: 3px solid var(--color-divine-green);
+	}
+
+	.auth-group.auth-client {
+		border-left: 3px solid #3b82f6;
+	}
+
+	.auth-group-header {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.auth-count-badge {
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--color-divine-text-secondary);
+	}
+
+	.auth-card-plain {
+		border: none;
+		border-left: none;
+		padding: 0.375rem 0;
+		background: transparent;
+		border-radius: 0;
+	}
+
+	.auth-sub-label {
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: var(--color-divine-text-secondary);
+	}
+
+	.auth-older-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		background: transparent;
+		border: 1px dashed var(--color-divine-border);
+		border-radius: 6px;
+		padding: 0.25rem 0.5rem;
+		font-size: 0.75rem;
+		color: var(--color-divine-text-secondary);
+		cursor: pointer;
+		align-self: flex-start;
+	}
+
+	.auth-older-toggle:hover {
+		background: var(--color-divine-surface);
+		color: var(--color-divine-text);
+	}
+
+	.auth-older-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		border-top: 1px dashed var(--color-divine-border);
+		padding-top: 0.375rem;
+	}
+
+	.auth-card-older {
+		opacity: 0.75;
 	}
 
 	.auth-card-header {


### PR DESCRIPTION
## Summary
Groups authorizations by label in the Synvya support-admin user detail view so a restaurant key with many rows renders as one card per label with an "N older" disclosure, instead of a flat scroll.

Motivates: production restaurants accumulating 4× `Synvya Client (staging)` / 2× `Synvya Server (staging)` rows per key (see PR #15 discussion). Duplicate creation is fixed in the Synvya client; cleanup is fixed in #18; this PR is the admin UX so the page is readable regardless of how many rows exist.

## Changes
- `groupAuthorizations(auths)` helper: buckets by label (empty labels → `(no label)`); newest-first inside each group; groups sorted by most-recent row.
- Per-group card: color accent (green = `Synvya Server`, blue = `Synvya Client`) moves to the group header; row count badge on the header.
- Newest row shown inline; `N older {label} authorizations` disclosure expands the rest.
- Only active in the Synvya-gated view (`isSynvyaManaged`); diVine deployments keep the existing flat rendering.
- Supporting CSS for `.auth-group`, `.auth-group-header`, `.auth-count-badge`, `.auth-card-plain`, `.auth-older-toggle`, `.auth-older-list`, `.auth-card-older`.

## Out of scope (per #19)
- No backend response-shape change — grouping is purely client-side.
- No dedupe-on-create (belongs in the Synvya client).
- Revoked-row toggle + grayed-out rendering: now that #18 has landed, this is a good follow-up; opening a separate issue once the endpoint is wired into the UI.

## Test plan
- [x] `svelte-check` clean for this file (pre-existing errors elsewhere in the repo are unrelated).
- [x] `vite build` transforms the file cleanly (build fails later on an unrelated unbuilt `keycast-login/dist` — not touched by this PR).
- [ ] Manual: open `/support-admin`, look up a user with a team whose restaurant key has duplicate-label authorizations; confirm one card per label, newest inline, N older expands, diVine rendering unchanged.
- [ ] Manual: user with zero duplicates still renders cleanly (one row per group, no disclosure).

## Acceptance criteria
- [x] Restaurant with 4× same-label auths renders as one card + "+3 older" disclosure.
- [x] Visible row is always newest in its label group.
- [x] Expanding reveals older rows inline with full meta.
- [x] diVine (non-Synvya) deployments unaffected.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)