### PR TITLE
feat(invitations): return email in preview + point invite links at client

### DIFF
--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -801,6 +801,7 @@ pub async fn preview_invitation(
         role: invitation.role,
         invited_by_display_name: inviter_name,
         expires_at: invitation.expires_at,
+        email: invitation.email,
     }))
 }
 

--- a/core/src/types/team_invitation.rs
+++ b/core/src/types/team_invitation.rs
@@ -50,6 +50,10 @@ pub struct InvitationPreview {
     pub role: String,
     pub invited_by_display_name: String,
     pub expires_at: DateTime<Utc>,
+    /// The email address the invitation was sent to. Returned so the client can
+    /// prefill and lock the email field on the signup/login forms, preventing
+    /// the "registered with a different email" → 403-at-accept-time footgun.
+    pub email: String,
 }
 
 /// Generate a cryptographically random invitation token (32 bytes, hex-encoded = 64 chars)

--- a/docker-compose.synvya.yml
+++ b/docker-compose.synvya.yml
@@ -73,6 +73,7 @@ services:
       FROM_NAME: ${FROM_NAME:-Synvya}
       BASE_URL: ${BASE_URL:?error}
       APP_URL: ${APP_URL:?error}
+      INVITE_BASE_URL: ${INVITE_BASE_URL:?error}
       DISABLE_EMAILS:
       # Frontend
       VITE_DOMAIN: ${VITE_DOMAIN:-}

--- a/docs/synvya/team-invite-by-email.md
+++ b/docs/synvya/team-invite-by-email.md
@@ -187,13 +187,16 @@ Returns enough data for the client to render the invite landing page without aut
   "team_name": "Taqueria La Estrella",
   "role": "Member",
   "invited_by_display_name": "Alejandro",
-  "expires_at": "2026-04-19T..."
+  "expires_at": "2026-04-19T...",
+  "email": "muralirk@gmail.com"
 }
 ```
 
-Returns 404 if the token is invalid, expired, accepted, or revoked. The response intentionally omits the token itself (it's in the query string already) and the email (privacy — the link holder may not be the intended recipient).
+Returns 404 if the token is invalid, expired, accepted, or revoked. The response intentionally omits the token itself (it's already in the query string).
 
-**Security**: This endpoint leaks the team name and inviter name to anyone with the token. Since tokens are 256-bit random, this is acceptable. The token URL is only sent via email.
+The `email` field echoes the invitation's stored email so the client can prefill and lock the email field on the signup/login forms. This prevents the invitee from registering a Synvya account with a different address and hitting a 403 at `POST /api/invitations/accept`.
+
+**Security**: This endpoint leaks the team name, inviter name, and invited email to anyone holding the token. Since tokens are 256-bit random and only delivered via email, the token holder is already authorized to act on the invitation — echoing the email does not widen the threat model.
 
 ### 3.5 `POST /api/invitations/accept`
 

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -17,9 +17,11 @@ get_secret() {
 if [ "$ENV" = "staging" ]; then
     DOMAIN=auth.staging.synvya.com
     KMS_KEY_ID=alias/keycast-master-key
+    INVITE_BASE_URL=https://account.staging.synvya.com
 elif [ "$ENV" = "production" ]; then
     DOMAIN=auth.synvya.com
     KMS_KEY_ID=alias/synvya-production-keycast-masterkey
+    INVITE_BASE_URL=https://account.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1
@@ -40,6 +42,7 @@ BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social
 ALLOWED_ORIGINS=https://$DOMAIN,$EXTRA_ALLOWED_ORIGINS
 BASE_URL=https://$DOMAIN
 APP_URL=https://$DOMAIN
+INVITE_BASE_URL=$INVITE_BASE_URL
 VITE_DOMAIN=https://$DOMAIN
 FROM_EMAIL=noreply@synvya.com
 FROM_NAME=Synvya


### PR DESCRIPTION
## Summary

Unblocks the `/accept-invite` flow that the Synvya client just implemented. Two coordinated changes:

- **`GET /api/invitations/preview` now returns `email`** so the client can prefill and lock the email field on signup/login. Prevents the invitee-registers-with-the-wrong-address → 403-at-accept footgun. Public threat model unchanged (token holder is already authorized to act on the invitation).
- **`INVITE_BASE_URL` wired through per environment** — staging → `https://account.staging.synvya.com`, production → `https://account.synvya.com`. Without this the fallback chain in `teams.rs` landed on `BASE_URL` (= `auth.*.synvya.com`), where `DISABLE_WEB_UI=true` redirects non-API requests to `synvya.com` — so invitees never reached an accept page.

`ALLOWED_ORIGINS` already includes the `account.*` origins via `scripts/load-secrets.sh`; left untouched.

## Files

- `core/src/types/team_invitation.rs` — add `email: String` to `InvitationPreview`.
- `api/src/api/http/teams.rs` — populate it from the invitation row in `preview_invitation`.
- `scripts/load-secrets.sh` — set `INVITE_BASE_URL` per env and write it to `/opt/synvya/.env`.
- `docker-compose.synvya.yml` — forward `INVITE_BASE_URL` to the container (required: `:?error`).
- `docs/synvya/team-invite-by-email.md` — update the response example and the privacy note.

## Test plan

- [ ] `cargo check -p keycast_core -p keycast_api` passes (verified locally).
- [ ] After deploy to staging: re-run `scripts/load-secrets.sh staging` on the host and restart the stack so compose picks up `INVITE_BASE_URL` (compose will refuse to start without it — fail-fast by design).
- [ ] Send a test invite and confirm the link in the email points at `https://account.staging.synvya.com/accept-invite?token=...`.
- [ ] `curl https://auth.staging.synvya.com/api/invitations/preview?token=<token>` returns JSON with a non-empty `email` field.
- [ ] End-to-end: new invitee lands on client page, registers with the prefilled email, verifies, accepts, shows up as a team member.
- [ ] Repeat on production after staging validation.

## Deployment note

`INVITE_BASE_URL` is declared with `:?error` in compose, matching the `BASE_URL`/`APP_URL` pattern. The next deploy will fail loudly if the host's `/opt/synvya/.env` wasn't regenerated — which is the desired behavior; do not downgrade to a soft default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)