### PR TITLE
feat(teams): include member email in TeamUser roster responses

### DIFF
--- a/core/src/repositories/team.rs
+++ b/core/src/repositories/team.rs
@@ -43,8 +43,10 @@ impl TeamRepository {
 
         // Get team_users for this team
         let team_users = sqlx::query_as::<_, TeamUser>(
-            "SELECT user_pubkey, team_id, role, created_at, updated_at
-             FROM team_users WHERE team_id = $1",
+            "SELECT tu.user_pubkey, tu.team_id, tu.role, u.email, tu.created_at, tu.updated_at
+             FROM team_users tu
+             LEFT JOIN users u ON u.pubkey = tu.user_pubkey
+             WHERE tu.team_id = $1",
         )
         .bind(team_id)
         .fetch_all(&self.pool)
@@ -199,9 +201,14 @@ impl TeamRepository {
         role: &str,
     ) -> Result<TeamUser, RepositoryError> {
         sqlx::query_as::<_, TeamUser>(
-            "INSERT INTO team_users (team_id, user_pubkey, role, created_at, updated_at)
-             VALUES ($1, $2, $3, NOW(), NOW())
-             RETURNING user_pubkey, team_id, role, created_at, updated_at",
+            "WITH ins AS (
+                 INSERT INTO team_users (team_id, user_pubkey, role, created_at, updated_at)
+                 VALUES ($1, $2, $3, NOW(), NOW())
+                 RETURNING user_pubkey, team_id, role, created_at, updated_at
+             )
+             SELECT ins.user_pubkey, ins.team_id, ins.role, u.email, ins.created_at, ins.updated_at
+             FROM ins
+             LEFT JOIN users u ON u.pubkey = ins.user_pubkey",
         )
         .bind(team_id)
         .bind(pubkey)
@@ -213,16 +220,15 @@ impl TeamRepository {
 
     /// Check if a user is already a member of a team.
     pub async fn is_member(&self, team_id: i32, pubkey: &str) -> Result<bool, RepositoryError> {
-        let result = sqlx::query_as::<_, TeamUser>(
-            "SELECT user_pubkey, team_id, role, created_at, updated_at
-             FROM team_users WHERE team_id = $1 AND user_pubkey = $2",
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM team_users WHERE team_id = $1 AND user_pubkey = $2",
         )
         .bind(team_id)
         .bind(pubkey)
-        .fetch_optional(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
 
-        Ok(result.is_some())
+        Ok(count > 0)
     }
 
     /// Get a team member.
@@ -232,8 +238,10 @@ impl TeamRepository {
         pubkey: &str,
     ) -> Result<TeamUser, RepositoryError> {
         sqlx::query_as::<_, TeamUser>(
-            "SELECT user_pubkey, team_id, role, created_at, updated_at
-             FROM team_users WHERE team_id = $1 AND user_pubkey = $2",
+            "SELECT tu.user_pubkey, tu.team_id, tu.role, u.email, tu.created_at, tu.updated_at
+             FROM team_users tu
+             LEFT JOIN users u ON u.pubkey = tu.user_pubkey
+             WHERE tu.team_id = $1 AND tu.user_pubkey = $2",
         )
         .bind(team_id)
         .bind(pubkey)
@@ -381,9 +389,14 @@ impl TeamRepository {
 
         // Add user as admin
         let team_user = sqlx::query_as::<_, TeamUser>(
-            "INSERT INTO team_users (team_id, user_pubkey, role, created_at, updated_at)
-             VALUES ($1, $2, 'admin', $3, $4)
-             RETURNING *",
+            "WITH ins AS (
+                 INSERT INTO team_users (team_id, user_pubkey, role, created_at, updated_at)
+                 VALUES ($1, $2, 'admin', $3, $4)
+                 RETURNING user_pubkey, team_id, role, created_at, updated_at
+             )
+             SELECT ins.user_pubkey, ins.team_id, ins.role, u.email, ins.created_at, ins.updated_at
+             FROM ins
+             LEFT JOIN users u ON u.pubkey = ins.user_pubkey",
         )
         .bind(team.id)
         .bind(admin_pubkey)
@@ -750,5 +763,66 @@ mod tests {
         let with_relations = with_relations.unwrap();
         assert_eq!(with_relations.team.id, team.id);
         assert_eq!(with_relations.team_users.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_add_member_populates_email() {
+        let pool = setup_pool().await;
+        let team_repo = TeamRepository::new(pool.clone());
+        let user_repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+
+        let keys = Keys::generate();
+        let pubkey = keys.public_key();
+        user_repo.find_or_create(1, &pubkey).await.unwrap();
+
+        let email = format!("member-{}@test.local", suffix);
+        sqlx::query("UPDATE users SET email = $1 WHERE pubkey = $2")
+            .bind(&email)
+            .bind(pubkey.to_hex())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let team = team_repo
+            .create(1, &format!("Email Test {}", suffix))
+            .await
+            .unwrap();
+
+        let member = team_repo
+            .add_member(team.id, &pubkey.to_hex(), "member")
+            .await
+            .unwrap();
+        assert_eq!(member.email.as_deref(), Some(email.as_str()));
+
+        let with_relations = team_repo.find_with_relations(1, team.id).await.unwrap();
+        assert_eq!(with_relations.team_users.len(), 1);
+        assert_eq!(
+            with_relations.team_users[0].email.as_deref(),
+            Some(email.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_member_without_email_returns_none() {
+        let pool = setup_pool().await;
+        let team_repo = TeamRepository::new(pool.clone());
+        let user_repo = UserRepository::new(pool.clone());
+        let suffix = test_suffix();
+
+        let keys = Keys::generate();
+        let pubkey = keys.public_key();
+        user_repo.find_or_create(1, &pubkey).await.unwrap();
+
+        let team = team_repo
+            .create(1, &format!("NoEmail Test {}", suffix))
+            .await
+            .unwrap();
+
+        let member = team_repo
+            .add_member(team.id, &pubkey.to_hex(), "member")
+            .await
+            .unwrap();
+        assert!(member.email.is_none());
     }
 }

--- a/core/src/types/team.rs
+++ b/core/src/types/team.rs
@@ -86,8 +86,10 @@ impl Team {
 
         // Get team_users for this team
         let team_users = sqlx::query_as::<_, TeamUser>(
-            "SELECT user_pubkey, team_id, role, created_at, updated_at
-             FROM team_users WHERE team_id = $1",
+            "SELECT tu.user_pubkey, tu.team_id, tu.role, u.email, tu.created_at, tu.updated_at
+             FROM team_users tu
+             LEFT JOIN users u ON u.pubkey = tu.user_pubkey
+             WHERE tu.team_id = $1",
         )
         .bind(team_id)
         .fetch_all(pool)

--- a/core/src/types/user.rs
+++ b/core/src/types/user.rs
@@ -46,6 +46,9 @@ pub struct TeamUser {
     pub team_id: i32,
     /// The user's role in the team
     pub role: TeamUserRole,
+    /// The user's email, if any. Populated via LEFT JOIN on the `users` table.
+    #[serde(default)]
+    pub email: Option<String>,
     /// The date and time the user was created
     pub created_at: DateTime<chrono::Utc>,
     /// The date and time the user was last updated
@@ -117,8 +120,10 @@ impl User {
 
         // Batch fetch all team_users for all teams
         let all_team_users = sqlx::query_as::<_, TeamUser>(
-            "SELECT user_pubkey, team_id, role, created_at, updated_at
-             FROM team_users WHERE team_id = ANY($1)",
+            "SELECT tu.user_pubkey, tu.team_id, tu.role, u.email, tu.created_at, tu.updated_at
+             FROM team_users tu
+             LEFT JOIN users u ON u.pubkey = tu.user_pubkey
+             WHERE tu.team_id = ANY($1)",
         )
         .bind(&team_ids)
         .fetch_all(pool)

--- a/docs/synvya/team-invite-by-email.md
+++ b/docs/synvya/team-invite-by-email.md
@@ -302,7 +302,88 @@ let invitation_accept_route = Router::new()
 - The claim-token system (`/claim`, `/admin/claim-tokens`) is separate — it's for Vine-imported preloaded accounts, not team invitations.
 - The `EmailSender` trait gains one new method; existing email types are untouched.
 
-## 9. Implementation Order
+## 9. Team Member Email in Roster Responses
+
+Follow-on to the invitation flow. Once a member joins (either instantly via the "added" branch of `POST /teams/:id/invite` or after accepting an invitation), the client's Team Settings view needs to identify them by email instead of by truncated pubkey. See the client-side spec [§ 9](https://github.com/Synvya/client/blob/main/docs/specs/team-invite-by-email.md) for the UI rendering.
+
+### 9.1 Scope
+
+Extend the `TeamUser` serialization returned by team-membership endpoints to include the member's email. No new endpoints, no new permissions, no new auth surface.
+
+### 9.2 Wire Change
+
+Add `email` to every response that currently serializes `TeamUser`:
+
+```json
+{
+  "team_id": 5,
+  "user_pubkey": "abc...",
+  "role": "Admin",
+  "email": "manager@restaurant.com",
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+Affected endpoints (all already team-admin or team-member authenticated):
+
+| Endpoint | Where `TeamUser` appears |
+|---|---|
+| `GET /api/teams` | `team_users[]` inside each team |
+| `POST /api/teams/:id/users` | Response body |
+| `POST /api/teams/:id/invite` | `member` field of `{ status: "added", member: ... }` |
+| `GET /api/teams/:id/keys/:pubkey` | Indirectly if membership is echoed (verify per-handler) |
+
+### 9.3 Source of the Email
+
+The team_users row stores `user_pubkey`. The user's email lives on the `users` (or equivalent account) table keyed by pubkey. Serializing `TeamUser` requires a JOIN `team_users → users` or a batched lookup in the handler.
+
+Implementation note: where roster serialization is in a hot path (e.g. `GET /api/teams` for a user on many teams), a single JOIN at the SQL level is cheaper than N lookups in Rust.
+
+### 9.4 Privacy and Authorization
+
+- Callers already prove team membership to reach these endpoints; no new authorization layer is required.
+- Adding `email` to this surface does **not** widen the audience: everyone who currently sees the roster already sees the pubkey. Email is the same trust scope.
+- The privacy boundary is the team. Do not surface emails via any endpoint that returns team membership to non-members (if such an endpoint ever exists, it must strip `email`).
+
+### 9.5 Rust Type Change
+
+```rust
+// Whichever module defines the serialization DTO for team membership:
+
+#[derive(Serialize)]
+pub struct TeamUserResponse {
+    pub team_id: i32,
+    pub user_pubkey: String,
+    pub role: String,           // "Admin" | "Member"
+    pub email: String,          // ← new
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+```
+
+Repository method (or query builder) adjusted to fetch email alongside membership.
+
+### 9.6 Back-compat
+
+The field is additive. Older clients that don't know about `email` will ignore it. The current client (pre-release of this change) already tolerates the old shape; post-release it prefers `email` and falls back to the short npub label if absent.
+
+### 9.7 Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Member account deleted but team_users row lingers | Should not happen if CASCADE is in place; if it does, serialize with empty email (or filter the row out — whichever matches existing invariants). |
+| User has no email (claim-token-only account) | Serialize empty string. Client falls back to npub label. |
+| Tenant isolation | Email lookup must respect the same tenant boundary as the existing `users` query — never cross tenants. |
+
+### 9.8 Tests
+
+- Repository/query test: roster fetch returns email populated for a normal user.
+- Handler test: `GET /api/teams` response snapshot includes `email` on each `team_users` entry.
+- Handler test: `POST /api/teams/:id/invite` "added" branch response includes `email` on `member`.
+- Tenant isolation test: a user's email from tenant A never appears in tenant B's roster response.
+
+## 10. Implementation Order
 
 1. Migration: create `team_invitations` table
 2. Core: `TeamInvitation` type + `TeamInvitationRepository`


### PR DESCRIPTION
Implements [§ 9](docs/synvya/team-invite-by-email.md#9-team-member-email-in-roster-responses) of the team-invite-by-email spec: adds `email` to the `TeamUser` DTO so the client Team Settings view can identify members by email instead of truncated pubkey.

## Summary
- Add `email: Option<String>` to `TeamUser` in `core/src/types/user.rs`. Serializes to `null` when the user has no email (e.g. claim-token-only accounts). Back-compat: additive field, older clients ignore it.
- LEFT JOIN `users` on `pubkey` in every query that returns `TeamUser`. `users.pubkey` is a global primary key, so the JOIN is tenant-correct without threading `tenant_id` through roster queries.
- `add_member` and `create_with_admin` wrap `INSERT … RETURNING` in a CTE so the insert stays atomic while still picking up `email`.
- `is_member` switched to `SELECT COUNT(*)` — it was only checking existence, no reason to materialize a `TeamUser`.
- Spec §9 captured under `docs/synvya/team-invite-by-email.md`.

Affected endpoints (all already team-admin or team-member authenticated):
- `GET /api/teams` — `team_users[]` inside each team
- `GET /api/teams/:id` — `team_users[]` in `TeamWithRelations`
- `POST /api/teams/:id/users` — returns `TeamUser`
- `POST /api/teams/:id/invite` — `member` field of the `{ status: "added" }` branch

## Privacy
No new authorization surface. Callers already prove team membership to reach these endpoints; email lives in the same trust scope as the pubkey that's already exposed.

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --lib` — 47/47 pass in core
- [x] `cargo clippy --workspace --lib --tests -- -D warnings` — clean
- [ ] CI: integration tests (`test_add_member_populates_email`, `test_add_member_without_email_returns_none`) run against Postgres — cannot exercise locally (no local Postgres in this env)
- [ ] Client verifies email surfaces in Team Settings roster after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)