### PR TITLE
fix(cors): allow credentialed requests on /api/invitations/preview

### DIFF
--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -289,7 +289,7 @@ pub fn api_routes(
         .merge(signing_routes.layer(public_cors.clone()))
         .merge(nostr_rpc_routes.layer(public_cors.clone())) // NIP-46 RPC for OAuth apps
         .merge(team_routes.layer(auth_cors.clone())) // Team routes need credentials
-        .merge(invitation_preview_route.layer(public_cors.clone())) // Public - preview invite without auth
+        .merge(invitation_preview_route.layer(auth_cors.clone())) // Auth CORS - token-gated but clients may send credentials
         .merge(invitation_accept_route.layer(auth_cors.clone())) // Auth - accept invite needs session
         .merge(discovery_route.layer(public_cors.clone()))
         .merge(policy_routes.layer(public_cors.clone())) // Public - available to third-party OAuth apps


### PR DESCRIPTION
## Summary
- Switches `/api/invitations/preview` from `public_cors` (wildcard `*`, `allow_credentials: false`) to `auth_cors` (echoes allowed origin, `allow_credentials: true`) so browser clients whose shared fetch wrapper defaults to `credentials: "include"` no longer fail preflight.
- Endpoint remains unauthenticated — it's still token-gated via the URL.

Fixes #28

## Test plan
- [ ] OPTIONS preflight from an `ALLOWED_ORIGINS` origin with `Access-Control-Request-Headers: content-type` returns `Access-Control-Allow-Origin: <that origin>` and `Access-Control-Allow-Credentials: true`.
- [ ] OPTIONS preflight from a non-allowed origin is rejected.
- [ ] Existing callers without cookies continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)