### PR TITLE
feat(invitations): add team_key_pubkey and invited_by_email to preview

### DIFF
--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -793,13 +793,34 @@ pub async fn preview_invitation(
     let team_repo = TeamRepository::new(pool.clone());
     let team = team_repo.find(tenant_id, invitation.team_id).await?;
 
-    // Resolve inviter display name
+    // Resolve team's primary stored key pubkey (deterministic: earliest id wins).
+    // `None` if the team has no stored keys — keeps field shape stable for clients.
+    let team_key_pubkey: Option<String> = sqlx::query_scalar(
+        "SELECT pubkey FROM stored_keys
+         WHERE tenant_id = $1 AND team_id = $2
+         ORDER BY id ASC
+         LIMIT 1",
+    )
+    .bind(tenant_id)
+    .bind(invitation.team_id)
+    .fetch_optional(&pool)
+    .await
+    .map_err(|e| ApiError::internal(format!("Failed to load team key: {}", e)))?;
+
+    // Resolve inviter display name and email
     let inviter_name = resolve_display_name(&pool, &invitation.invited_by, tenant_id).await;
+    let user_repo = UserRepository::new(pool.clone());
+    let invited_by_email = user_repo
+        .get_email(&invitation.invited_by, tenant_id)
+        .await
+        .ok();
 
     Ok(Json(InvitationPreview {
         team_name: team.name,
+        team_key_pubkey,
         role: invitation.role,
         invited_by_display_name: inviter_name,
+        invited_by_email,
         expires_at: invitation.expires_at,
         email: invitation.email,
     }))

--- a/core/src/types/team_invitation.rs
+++ b/core/src/types/team_invitation.rs
@@ -47,8 +47,16 @@ pub struct InvitationListItem {
 #[derive(Debug, Serialize)]
 pub struct InvitationPreview {
     pub team_name: String,
+    /// Hex pubkey of the team's primary stored key. `None` if the team has no
+    /// stored keys yet. Lets the client fetch the team's kind-0 profile from
+    /// relays to render a display name and avatar instead of the raw team_name.
+    pub team_key_pubkey: Option<String>,
     pub role: String,
     pub invited_by_display_name: String,
+    /// Email address of the inviter (Keycast user). `None` if the inviter's
+    /// account is missing an email. Lets the client render a human-readable
+    /// "invited you" line instead of a truncated pubkey.
+    pub invited_by_email: Option<String>,
     pub expires_at: DateTime<Utc>,
     /// The email address the invitation was sent to. Returned so the client can
     /// prefill and lock the email field on the signup/login forms, preventing

--- a/docs/synvya/team-invite-by-email.md
+++ b/docs/synvya/team-invite-by-email.md
@@ -185,8 +185,10 @@ Returns enough data for the client to render the invite landing page without aut
 ```json
 {
   "team_name": "Taqueria La Estrella",
+  "team_key_pubkey": "5e7f...",
   "role": "Member",
   "invited_by_display_name": "Alejandro",
+  "invited_by_email": "alejandro@synvya.com",
   "expires_at": "2026-04-19T...",
   "email": "muralirk@gmail.com"
 }
@@ -196,7 +198,11 @@ Returns 404 if the token is invalid, expired, accepted, or revoked. The response
 
 The `email` field echoes the invitation's stored email so the client can prefill and lock the email field on the signup/login forms. This prevents the invitee from registering a Synvya account with a different address and hitting a 403 at `POST /api/invitations/accept`.
 
-**Security**: This endpoint leaks the team name, inviter name, and invited email to anyone holding the token. Since tokens are 256-bit random and only delivered via email, the token holder is already authorized to act on the invitation — echoing the email does not widen the threat model.
+The `team_key_pubkey` field is the hex pubkey of the team's primary stored key (the signer behind the team's Nostr identity). The client uses it to fetch the team's kind-0 profile from relays and render a display name + avatar instead of the raw `team_name` handle. `null` if the team has no stored key yet.
+
+The `invited_by_email` field is the inviter's Keycast user email. Lets the client render `"alejandro@synvya.com invited you to join..."` instead of a truncated pubkey. `null` if the inviter's account has no email on file.
+
+**Security**: This endpoint leaks the team name, team signing pubkey, inviter name, inviter email, and invited email to anyone holding the token. Since tokens are 256-bit random and only delivered via email, the token holder is already authorized to act on the invitation. Exposing `invited_by_email` is acceptable in this flow — the inviter explicitly chose to invite this person — but is a deliberate widening relative to the prior response shape.
 
 ### 3.5 `POST /api/invitations/accept`
 


### PR DESCRIPTION
## Summary
- Adds `team_key_pubkey` (primary stored_keys pubkey, deterministic by `id ASC`) and `invited_by_email` (inviter's Keycast email) to `GET /api/invitations/preview`.
- Both fields are `Option<String>` / nullable — shape stays stable when data is missing.
- Additive change; existing clients unaffected.
- Docs updated in [docs/synvya/team-invite-by-email.md](docs/synvya/team-invite-by-email.md).

Closes #29.

## Why
Lets the `/accept-invite` page render the team's kind-0 display name + avatar (via relays) and show the inviter as `alejandro@synvya.com` instead of `f7ebfcf1…`.

## Privacy note
`invited_by_email` exposes the inviter's email to whoever holds the 256-bit invite token. Acceptable because the inviter explicitly chose to invite this person, and the token is only delivered by email. Called out in the docs' Security section.

## Test plan
- [x] `cargo check -p keycast_api -p keycast_core` passes
- [x] `cargo test --lib` in `api/` — 57 passed
- [ ] Manual: hit `GET /api/invitations/preview?token=...` against a staging invite and confirm both new fields appear with expected values
- [ ] Manual: confirm teams with no stored key return `team_key_pubkey: null` rather than a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)