### PR TITLE
fix(email): route /verify-email past DISABLE_WEB_UI; split password reset URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,8 +201,9 @@ Optional:
 - `SQLX_POOL_SIZE`: Database connection pool size (should match Cloud Run concurrency, default: `50`)
 - `VITE_ALLOWED_PUBKEYS`: Comma-separated pubkeys for whitelist access (web frontend)
 - `ENABLE_EXAMPLES`: Enable `/examples` directory serving (default: `false`, set to `true` for development)
-- `DISABLE_WEB_UI`: Disable the SvelteKit web frontend (default: `false`). When `true`, non-API requests return 404 or redirect to `WEB_UI_REDIRECT_URL`. Use for deployments (e.g. Synvya) where end users should not access a keycast personal UI. `/api/*`, `/.well-known/*`, `/health*`, and the server-rendered `/api/oauth/authorize` approval page remain available.
+- `DISABLE_WEB_UI`: Disable the SvelteKit web frontend (default: `false`). When `true`, non-API requests return 404 or redirect to `WEB_UI_REDIRECT_URL`. Use for deployments (e.g. Synvya) where end users should not access a keycast personal UI. `/api/*`, `/.well-known/*`, `/health*`, `/verify-email` (plus the `/_app/*` static assets it needs), and the server-rendered `/api/oauth/authorize` approval page remain available.
 - `WEB_UI_REDIRECT_URL`: When `DISABLE_WEB_UI=true`, redirect non-API requests to this URL (e.g. `https://synvya.com`). If unset, non-API requests return 404.
+- `PASSWORD_RESET_BASE_URL`: Base URL used when constructing password reset links in emails (default: `BASE_URL`). Set when the reset page is hosted on a different domain than `BASE_URL` — e.g. Synvya sets this to `https://account.synvya.com` in production and `https://account.staging.synvya.com` in staging, so the link points at the Synvya-hosted reset form that POSTs to keycast's `/api/auth/reset-password`.
 
 Development (`.env` in `/web`):
 - `VITE_ALLOWED_PUBKEYS`: Comma-separated pubkeys for dev access

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -53,6 +53,16 @@ pub trait EmailSender: Send + Sync {
     }
 }
 
+/// Resolve the base URL used in password reset links.
+///
+/// Defaults to `BASE_URL` but may be overridden via `PASSWORD_RESET_BASE_URL`
+/// when the password reset page is hosted on a different domain than the
+/// rest of the email flow (e.g. Synvya deployments host the reset form on
+/// `account.synvya.com` while verification stays on `auth.synvya.com`).
+fn password_reset_base_url(default: &str) -> String {
+    env::var("PASSWORD_RESET_BASE_URL").unwrap_or_else(|_| default.to_string())
+}
+
 // ---------------------------------------------------------------------------
 // Shared email templates (used by SendGrid, SES, and any future providers)
 // ---------------------------------------------------------------------------
@@ -198,6 +208,7 @@ fn team_invite_text(team_name: &str, inviter_name: &str, role: &str, invite_url:
 /// Development email sender - logs URLs to console and captures emails for testing
 pub struct DevEmailSender {
     base_url: String,
+    password_reset_base_url: String,
     captured: Arc<Mutex<Vec<CapturedEmail>>>,
 }
 
@@ -206,15 +217,18 @@ impl DevEmailSender {
         let base_url = env::var("BASE_URL")
             .or_else(|_| env::var("APP_URL"))
             .unwrap_or_else(|_| "http://localhost:5173".to_string());
+        let password_reset_base_url = password_reset_base_url(&base_url);
 
         tracing::info!("===========================================");
         tracing::info!("  EMAIL SERVICE: Development Mode");
         tracing::info!("  Emails will be logged to console");
         tracing::info!("  Base URL: {}", base_url);
+        tracing::info!("  Password reset base URL: {}", password_reset_base_url);
         tracing::info!("===========================================");
 
         Self {
             base_url,
+            password_reset_base_url,
             captured: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -279,7 +293,10 @@ impl EmailSender for DevEmailSender {
         to_email: &str,
         reset_token: &str,
     ) -> Result<(), String> {
-        let reset_url = format!("{}/reset-password?token={}", self.base_url, reset_token);
+        let reset_url = format!(
+            "{}/reset-password?token={}",
+            self.password_reset_base_url, reset_token
+        );
 
         tracing::info!("");
         tracing::info!("==================================================");
@@ -449,6 +466,7 @@ pub struct SendGridEmailSender {
     from_email: String,
     from_name: String,
     base_url: String,
+    password_reset_base_url: String,
 }
 
 impl SendGridEmailSender {
@@ -459,14 +477,19 @@ impl SendGridEmailSender {
         let base_url = env::var("BASE_URL")
             .or_else(|_| env::var("APP_URL"))
             .unwrap_or_else(|_| "http://localhost:5173".to_string());
+        let password_reset_base_url = password_reset_base_url(&base_url);
 
-        tracing::info!("Email service initialized with SendGrid");
+        tracing::info!(
+            "Email service initialized with SendGrid (reset base URL: {})",
+            password_reset_base_url
+        );
 
         Self {
             api_key,
             from_email,
             from_name,
             base_url,
+            password_reset_base_url,
         }
     }
 
@@ -564,7 +587,10 @@ impl EmailSender for SendGridEmailSender {
         to_email: &str,
         reset_token: &str,
     ) -> Result<(), String> {
-        let reset_url = format!("{}/reset-password?token={}", self.base_url, reset_token);
+        let reset_url = format!(
+            "{}/reset-password?token={}",
+            self.password_reset_base_url, reset_token
+        );
         let subject = "Reset your Synvya password";
         let html = password_reset_html(&reset_url);
         let text = password_reset_text(&reset_url);
@@ -606,6 +632,7 @@ pub struct SesEmailSender {
     from_email: String,
     from_name: String,
     base_url: String,
+    password_reset_base_url: String,
 }
 
 #[cfg(feature = "aws")]
@@ -626,11 +653,13 @@ impl SesEmailSender {
         let base_url = env::var("BASE_URL")
             .or_else(|_| env::var("APP_URL"))
             .unwrap_or_else(|_| "http://localhost:5173".to_string());
+        let password_reset_base_url = password_reset_base_url(&base_url);
 
         tracing::info!(
-            "AWS SES email sender initialized (region: {}, from: {})",
+            "AWS SES email sender initialized (region: {}, from: {}, reset base URL: {})",
             region,
-            from_email
+            from_email,
+            password_reset_base_url
         );
 
         Ok(Self {
@@ -638,6 +667,7 @@ impl SesEmailSender {
             from_email,
             from_name,
             base_url,
+            password_reset_base_url,
         })
     }
 
@@ -735,7 +765,10 @@ impl EmailSender for SesEmailSender {
         to_email: &str,
         reset_token: &str,
     ) -> Result<(), String> {
-        let reset_url = format!("{}/reset-password?token={}", self.base_url, reset_token);
+        let reset_url = format!(
+            "{}/reset-password?token={}",
+            self.password_reset_base_url, reset_token
+        );
         let subject = "Reset your Synvya password";
         let html = password_reset_html(&reset_url);
         let text = password_reset_text(&reset_url);

--- a/docker-compose.synvya.yml
+++ b/docker-compose.synvya.yml
@@ -74,6 +74,9 @@ services:
       BASE_URL: ${BASE_URL:?error}
       APP_URL: ${APP_URL:?error}
       INVITE_BASE_URL: ${INVITE_BASE_URL:?error}
+      # Synvya hosts the password reset page on a different domain
+      # (account.synvya.com / account.staging.synvya.com) from the auth host.
+      PASSWORD_RESET_BASE_URL: ${PASSWORD_RESET_BASE_URL:?error}
       DISABLE_EMAILS:
       # Frontend
       VITE_DOMAIN: ${VITE_DOMAIN:-}

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -754,15 +754,37 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
             }
         );
 
-        app.fallback(axum::routing::any(move || {
-            let redirect_url = redirect_url.clone();
+        // Email verification links land on /verify-email, a SvelteKit SPA route.
+        // Even in DISABLE_WEB_UI deployments we must serve this page (plus its JS/CSS
+        // assets) so the client can POST the token to /api/auth/verify-email.
+        let index_path = PathBuf::from(&web_build_dir).join("index.html");
+        let verify_index_path = index_path.clone();
+        let verify_email_handler = move || {
+            let index_path = verify_index_path.clone();
             async move {
-                match redirect_url {
-                    Some(url) => axum::response::Redirect::temporary(&url).into_response(),
-                    None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+                match tokio::fs::read_to_string(&index_path).await {
+                    Ok(content) => Html(inject_runtime_env(&content)).into_response(),
+                    Err(_) => (StatusCode::NOT_FOUND, "Not found").into_response(),
                 }
             }
-        }))
+        };
+
+        let app = app.route("/verify-email", axum::routing::get(verify_email_handler));
+
+        // Serve SvelteKit static assets (/_app/*, favicon, logos) needed by the
+        // verify-email page; unmatched routes redirect to WEB_UI_REDIRECT_URL.
+        let redirect_url_for_fallback = redirect_url.clone();
+        app.fallback_service(ServeDir::new(&web_build_dir).fallback(axum::routing::any(
+            move || {
+                let redirect_url = redirect_url_for_fallback.clone();
+                async move {
+                    match redirect_url {
+                        Some(url) => axum::response::Redirect::temporary(&url).into_response(),
+                        None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+                    }
+                }
+            },
+        )))
     } else {
         // SvelteKit frontend - explicitly handle root and index.html with injection
         // This ensures index.html always goes through injection, not served as static file

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -18,10 +18,12 @@ if [ "$ENV" = "staging" ]; then
     DOMAIN=auth.staging.synvya.com
     KMS_KEY_ID=alias/keycast-master-key
     INVITE_BASE_URL=https://account.staging.synvya.com
+    PASSWORD_RESET_BASE_URL=https://account.staging.synvya.com
 elif [ "$ENV" = "production" ]; then
     DOMAIN=auth.synvya.com
     KMS_KEY_ID=alias/synvya-production-keycast-masterkey
     INVITE_BASE_URL=https://account.synvya.com
+    PASSWORD_RESET_BASE_URL=https://account.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1
@@ -43,6 +45,7 @@ ALLOWED_ORIGINS=https://$DOMAIN,$EXTRA_ALLOWED_ORIGINS
 BASE_URL=https://$DOMAIN
 APP_URL=https://$DOMAIN
 INVITE_BASE_URL=$INVITE_BASE_URL
+PASSWORD_RESET_BASE_URL=$PASSWORD_RESET_BASE_URL
 VITE_DOMAIN=https://$DOMAIN
 FROM_EMAIL=noreply@synvya.com
 FROM_NAME=Synvya


### PR DESCRIPTION
## Summary

- **`/verify-email` redirect bug.** Synvya keycast runs with `DISABLE_WEB_UI=true` and `WEB_UI_REDIRECT_URL=https://www.synvya.com`, so the fallback was catching `/verify-email` (a SvelteKit SPA route) and bouncing invited users to the marketing site before they could verify. Allowlist that route in the disabled-UI branch: serve `index.html` with runtime env injection, plus `ServeDir(web_build_dir)` underneath so the SPA's `/_app/*` assets load. Unknown routes still redirect.
- **Configurable password reset base URL.** Synvya hosts its own `/reset-password` page on `account.{staging.,}synvya.com` (it already POSTs to keycast's `/api/auth/reset-password`). New `PASSWORD_RESET_BASE_URL` env var (defaults to `BASE_URL`) is threaded through `DevEmailSender`, `SendGridEmailSender`, and `SesEmailSender`. `scripts/load-secrets.sh` sets it to the correct per-env URL, and `docker-compose.synvya.yml` requires it (`:?error`).
- Docs updated in `CLAUDE.md`.

Verification URL is unchanged — it still uses `BASE_URL` (`auth.{staging.,}synvya.com`), and the allowlist makes that work again.

## Test plan

- [ ] `cargo check -p keycast` and `cargo check -p keycast_api --features aws` pass (verified locally).
- [ ] After deploy to staging, register a new team member and confirm the verification email link resolves to `https://auth.staging.synvya.com/verify-email?token=...` and successfully verifies (no redirect to www.synvya.com).
- [ ] Trigger a password reset and confirm the email link points at `https://account.staging.synvya.com/reset-password?token=...`.
- [ ] Confirm deploy job writes `PASSWORD_RESET_BASE_URL` into `/opt/synvya/.env` and keycast picks it up (check `docker compose logs keycast` for the "reset base URL" log line).
- [ ] Hit a random unknown path (e.g. `/foo`) on staging and confirm it still redirects to `https://www.synvya.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)