### PR TITLE
feat(invitations): card-style invite email with kind-0 team profile

### DIFF
--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -659,11 +659,61 @@ pub async fn invite_user(
                 )
                 .await?;
 
-            // Resolve inviter display name
+            // Resolve inviter display name (used for the list response regardless of email outcome)
             let inviter_name = resolve_display_name(&pool, &user_pubkey_hex, tenant_id).await;
+
+            // For the email body we prefer a real display name → email → pubkey prefix.
+            // The admin's email is the most useful fallback when no kind-0 display name exists.
+            let inviter_real_display: Option<String> =
+                sqlx::query_as::<_, (Option<String>, Option<String>)>(
+                    "SELECT display_name, username FROM users WHERE pubkey = $1 AND tenant_id = $2",
+                )
+                .bind(&user_pubkey_hex)
+                .bind(tenant_id)
+                .fetch_optional(&pool)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|(dn, un)| {
+                    dn.filter(|s| !s.is_empty())
+                        .or_else(|| un.filter(|s| !s.is_empty()))
+                });
+            let inviter_email_opt = user_repo.get_email(&user_pubkey_hex, tenant_id).await.ok();
+            let inviter_label = inviter_real_display
+                .clone()
+                .or_else(|| inviter_email_opt.clone())
+                .unwrap_or_else(|| inviter_name.clone());
 
             // Resolve team name
             let team = team_repo.find(tenant_id, team_id).await?;
+
+            // Resolve team's primary stored key (used for kind-0 profile lookup).
+            let team_key_pubkey: Option<String> = sqlx::query_scalar(
+                "SELECT pubkey FROM stored_keys
+                 WHERE tenant_id = $1 AND team_id = $2
+                 ORDER BY id ASC
+                 LIMIT 1",
+            )
+            .bind(tenant_id)
+            .bind(team_id)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| ApiError::internal(format!("Failed to load team key: {}", e)))?;
+
+            // Best-effort kind-0 fetch so the email can show the team's real display
+            // name and avatar (same as the accept page). Falls back to the DB handle.
+            let profile = if let Some(ref pk) = team_key_pubkey {
+                let relays =
+                    keycast_core::types::authorization::Authorization::get_bunker_relays();
+                crate::nostr_profile::fetch_profile_metadata(pk, &relays).await
+            } else {
+                None
+            };
+            let team_display_name = profile
+                .as_ref()
+                .and_then(|p| p.display_name.clone())
+                .unwrap_or_else(|| team.name.clone());
+            let team_picture = profile.as_ref().and_then(|p| p.picture.clone());
 
             // Build invite URL
             let invite_base_url = std::env::var("INVITE_BASE_URL")
@@ -678,9 +728,11 @@ pub async fn invite_user(
                     if let Err(e) = email_service
                         .send_team_invite_email(
                             &email,
-                            &team.name,
-                            &inviter_name,
+                            &team_display_name,
+                            team_picture.as_deref(),
+                            &inviter_label,
                             role_str,
+                            invitation.expires_at,
                             &invite_url,
                         )
                         .await

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Supports SendGrid for production, AWS SES (behind `aws` feature), and DevEmailSender for local development/testing
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use std::env;
 use std::sync::{Arc, Mutex};
@@ -33,12 +34,20 @@ pub trait EmailSender: Send + Sync {
     async fn send_claim_email(&self, to_email: &str, claim_url: &str) -> Result<(), String>;
 
     /// Send a team invitation email.
+    ///
+    /// `team_display_name` should be the kind-0 display name when available,
+    /// falling back to the DB team handle. `team_picture` is an optional kind-0
+    /// avatar URL (http/https only; callers are responsible for validating).
+    /// `inviter_label` is the admin's email (preferred) or display name.
+    #[allow(clippy::too_many_arguments)]
     async fn send_team_invite_email(
         &self,
         to_email: &str,
-        team_name: &str,
-        inviter_name: &str,
+        team_display_name: &str,
+        team_picture: Option<&str>,
+        inviter_label: &str,
         role: &str,
+        expires_at: DateTime<Utc>,
         invite_url: &str,
     ) -> Result<(), String>;
 
@@ -169,35 +178,115 @@ fn claim_email_text(claim_url: &str) -> String {
     )
 }
 
-fn team_invite_html(team_name: &str, inviter_name: &str, role: &str, invite_url: &str) -> String {
+/// Minimal HTML-attribute/text escape for values interpolated into the template.
+/// Handles the five chars that matter in body text and double-quoted attributes.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Keep only http/https URLs; reject anything else to avoid `javascript:` etc.
+/// Returned string is already HTML-attribute-safe.
+fn safe_http_url(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+        Some(html_escape(trimmed))
+    } else {
+        None
+    }
+}
+
+fn title_case_role(role: &str) -> String {
+    let mut chars = role.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn team_invite_html(
+    team_display_name: &str,
+    team_picture: Option<&str>,
+    inviter_label: &str,
+    recipient_email: &str,
+    role: &str,
+    expires_at: DateTime<Utc>,
+    invite_url: &str,
+) -> String {
+    let team_name_esc = html_escape(team_display_name);
+    let inviter_esc = html_escape(inviter_label);
+    let recipient_esc = html_escape(recipient_email);
+    let role_esc = html_escape(&title_case_role(role));
+    let url_esc = html_escape(invite_url);
+    // "Apr 28, 2026" — date only, TZ-ambiguous time would confuse recipients.
+    let expires_fmt = expires_at.format("%b %-d, %Y").to_string();
+
+    let avatar_html = team_picture
+        .and_then(safe_http_url)
+        .map(|url| {
+            format!(
+                r#"<img src="{url}" alt="" width="72" height="72" style="width:72px; height:72px; border-radius:50%; object-fit:cover; display:block; margin:0 auto 16px;" />"#
+            )
+        })
+        .unwrap_or_default();
+
     format!(
-        r#"
-            <html>
-            <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <h1 style="color: #00B488;">You're invited to join {team_name}</h1>
-                <p><strong>{inviter_name}</strong> has invited you to join <strong>{team_name}</strong> as a <strong>{role}</strong> on Synvya.</p>
-                <div style="margin: 30px 0;">
-                    <a href="{invite_url}"
-                       style="background: #00B488; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
-                        Accept Invitation
-                    </a>
-                </div>
-                <p style="color: #666; font-size: 14px;">
-                    Or copy and paste this link into your browser:<br>
-                    <a href="{invite_url}" style="color: #00B488;">{invite_url}</a>
-                </p>
-                <p style="color: #666; font-size: 14px; margin-top: 30px;">
-                    This invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.
-                </p>
-            </body>
-            </html>
-            "#,
+        r#"<!doctype html>
+<html>
+<body style="margin:0; padding:0; background:#f5f5f5; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; color:#111;">
+  <div style="max-width:520px; margin:0 auto; padding:32px 20px;">
+    <div style="text-align:center; margin-bottom:24px;">
+      <span style="color:#00B488; font-size:20px; font-weight:600; letter-spacing:0.2px;">Synvya</span>
+    </div>
+    <h2 style="text-align:center; margin:0 0 20px; font-size:20px; font-weight:600;">Team Invitation</h2>
+    <div style="background:#fff; border-radius:12px; padding:28px 24px; text-align:center; border:1px solid #ececec;">
+      {avatar_html}<div style="font-size:18px; font-weight:600; margin-bottom:12px;">{team_name_esc}</div>
+      <div style="color:#444; font-size:14px; margin-bottom:10px;"><strong>{inviter_esc}</strong> invited you to join as <strong>{role_esc}</strong>.</div>
+      <div style="color:#888; font-size:13px;">Sent to <strong>{recipient_esc}</strong>. Expires {expires_fmt}.</div>
+    </div>
+    <div style="margin:28px 0; text-align:center;">
+      <a href="{url_esc}" style="display:inline-block; background:#00B488; color:#fff; padding:14px 36px; text-decoration:none; border-radius:8px; font-weight:600; font-size:15px;">Accept Invitation</a>
+    </div>
+    <p style="color:#666; font-size:13px; text-align:center; line-height:1.5; margin:0 8px;">
+      Or copy and paste this link into your browser:<br>
+      <a href="{url_esc}" style="color:#00B488; word-break:break-all;">{url_esc}</a>
+    </p>
+    <p style="color:#999; font-size:12px; text-align:center; margin-top:28px;">
+      This invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.
+    </p>
+  </div>
+</body>
+</html>
+"#
     )
 }
 
-fn team_invite_text(team_name: &str, inviter_name: &str, role: &str, invite_url: &str) -> String {
+fn team_invite_text(
+    team_display_name: &str,
+    inviter_label: &str,
+    recipient_email: &str,
+    role: &str,
+    expires_at: DateTime<Utc>,
+    invite_url: &str,
+) -> String {
+    let role_tc = title_case_role(role);
+    let expires_fmt = expires_at.format("%b %-d, %Y").to_string();
     format!(
-        "{inviter_name} has invited you to join {team_name} as a {role} on Synvya.\n\nAccept the invitation:\n{invite_url}\n\nThis invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.",
+        "Team Invitation — {team_display_name}\n\n\
+         {inviter_label} invited you to join as {role_tc}.\n\
+         Sent to {recipient_email}. Expires {expires_fmt}.\n\n\
+         Accept the invitation:\n{invite_url}\n\n\
+         This invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.\n",
     )
 }
 
@@ -362,9 +451,11 @@ impl EmailSender for DevEmailSender {
     async fn send_team_invite_email(
         &self,
         to_email: &str,
-        team_name: &str,
-        inviter_name: &str,
+        team_display_name: &str,
+        team_picture: Option<&str>,
+        inviter_label: &str,
         role: &str,
+        expires_at: DateTime<Utc>,
         invite_url: &str,
     ) -> Result<(), String> {
         tracing::info!("");
@@ -372,8 +463,10 @@ impl EmailSender for DevEmailSender {
         tracing::info!("  TEAM INVITATION EMAIL");
         tracing::info!("==================================================");
         tracing::info!("  To: {}", to_email);
-        tracing::info!("  Team: {} (as {})", team_name, role);
-        tracing::info!("  Invited by: {}", inviter_name);
+        tracing::info!("  Team: {} (as {})", team_display_name, role);
+        tracing::info!("  Invited by: {}", inviter_label);
+        tracing::info!("  Picture: {:?}", team_picture);
+        tracing::info!("  Expires: {}", expires_at);
         tracing::info!("");
         tracing::info!("  Accept link:");
         tracing::info!("  {}", invite_url);
@@ -382,13 +475,13 @@ impl EmailSender for DevEmailSender {
 
         eprintln!(
             "\n\x1b[35m[DEV EMAIL]\x1b[0m Team invite for {} to join {}: \x1b[4m{}\x1b[0m\n",
-            to_email, team_name, invite_url
+            to_email, team_display_name, invite_url
         );
 
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: format!("You've been invited to join {} on Synvya", team_name),
+                subject: format!("You've been invited to join {} on Synvya", team_display_name),
                 verification_url: Some(invite_url.to_string()),
                 reset_url: None,
             });
@@ -609,14 +702,34 @@ impl EmailSender for SendGridEmailSender {
     async fn send_team_invite_email(
         &self,
         to_email: &str,
-        team_name: &str,
-        inviter_name: &str,
+        team_display_name: &str,
+        team_picture: Option<&str>,
+        inviter_label: &str,
         role: &str,
+        expires_at: DateTime<Utc>,
         invite_url: &str,
     ) -> Result<(), String> {
-        let subject = format!("You've been invited to join {} on Synvya", team_name);
-        let html = team_invite_html(team_name, inviter_name, role, invite_url);
-        let text = team_invite_text(team_name, inviter_name, role, invite_url);
+        let subject = format!(
+            "You've been invited to join {} on Synvya",
+            team_display_name
+        );
+        let html = team_invite_html(
+            team_display_name,
+            team_picture,
+            inviter_label,
+            to_email,
+            role,
+            expires_at,
+            invite_url,
+        );
+        let text = team_invite_text(
+            team_display_name,
+            inviter_label,
+            to_email,
+            role,
+            expires_at,
+            invite_url,
+        );
 
         self.send_email(to_email, &subject, &html, &text).await
     }
@@ -787,14 +900,34 @@ impl EmailSender for SesEmailSender {
     async fn send_team_invite_email(
         &self,
         to_email: &str,
-        team_name: &str,
-        inviter_name: &str,
+        team_display_name: &str,
+        team_picture: Option<&str>,
+        inviter_label: &str,
         role: &str,
+        expires_at: DateTime<Utc>,
         invite_url: &str,
     ) -> Result<(), String> {
-        let subject = format!("You've been invited to join {} on Synvya", team_name);
-        let html = team_invite_html(team_name, inviter_name, role, invite_url);
-        let text = team_invite_text(team_name, inviter_name, role, invite_url);
+        let subject = format!(
+            "You've been invited to join {} on Synvya",
+            team_display_name
+        );
+        let html = team_invite_html(
+            team_display_name,
+            team_picture,
+            inviter_label,
+            to_email,
+            role,
+            expires_at,
+            invite_url,
+        );
+        let text = team_invite_text(
+            team_display_name,
+            inviter_label,
+            to_email,
+            role,
+            expires_at,
+            invite_url,
+        );
 
         self.send_email(to_email, &subject, &html, &text).await
     }
@@ -887,16 +1020,27 @@ impl EmailService {
         self.inner.send_claim_email(to_email, claim_url).await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn send_team_invite_email(
         &self,
         to_email: &str,
-        team_name: &str,
-        inviter_name: &str,
+        team_display_name: &str,
+        team_picture: Option<&str>,
+        inviter_label: &str,
         role: &str,
+        expires_at: DateTime<Utc>,
         invite_url: &str,
     ) -> Result<(), String> {
         self.inner
-            .send_team_invite_email(to_email, team_name, inviter_name, role, invite_url)
+            .send_team_invite_email(
+                to_email,
+                team_display_name,
+                team_picture,
+                inviter_label,
+                role,
+                expires_at,
+                invite_url,
+            )
             .await
     }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -5,6 +5,7 @@ pub mod divine_names;
 pub mod email_service;
 pub mod handlers;
 pub mod nip98;
+pub mod nostr_profile;
 pub mod redis;
 pub mod state;
 pub mod ucan_auth;

--- a/api/src/nostr_profile.rs
+++ b/api/src/nostr_profile.rs
@@ -1,0 +1,143 @@
+// ABOUTME: Fetch NIP-01 kind-0 metadata (name, picture) for a pubkey from configured relays.
+// ABOUTME: Best-effort with a short timeout; callers fall back to local data on failure.
+
+use nostr_sdk::prelude::*;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Overall deadline for the relay round-trip. Kept short because this runs
+/// inline in the invite-email HTTP handler.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Subset of kind-0 metadata we use in emails.
+#[derive(Debug, Clone, Default)]
+pub struct ProfileMetadata {
+    /// Preferred human-readable name (`display_name` → `name`).
+    pub display_name: Option<String>,
+    /// Avatar URL (`picture`).
+    pub picture: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Kind0Content {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    picture: Option<String>,
+}
+
+/// Fetch kind-0 metadata for `pubkey_hex` from the given relays.
+///
+/// Returns `None` on any failure (bad pubkey, no relays reachable, timeout,
+/// no event, malformed JSON). Callers should fall back to local data.
+pub async fn fetch_profile_metadata(
+    pubkey_hex: &str,
+    relays: &[String],
+) -> Option<ProfileMetadata> {
+    if relays.is_empty() {
+        return None;
+    }
+
+    let public_key = match PublicKey::from_hex(pubkey_hex) {
+        Ok(pk) => pk,
+        Err(e) => {
+            tracing::warn!("fetch_profile_metadata: invalid pubkey {}: {}", pubkey_hex, e);
+            return None;
+        }
+    };
+
+    let client = Client::default();
+    for relay in relays {
+        if let Err(e) = client.add_relay(relay.as_str()).await {
+            tracing::debug!("fetch_profile_metadata: add_relay {} failed: {}", relay, e);
+        }
+    }
+    client.connect().await;
+
+    let filter = Filter::new()
+        .author(public_key)
+        .kind(Kind::Metadata)
+        .limit(1);
+
+    let result = match client.fetch_events(filter, FETCH_TIMEOUT).await {
+        Ok(events) => events
+            .into_iter()
+            .next()
+            .and_then(|ev| parse_kind0(&ev.content)),
+        Err(e) => {
+            tracing::warn!(
+                "fetch_profile_metadata: fetch_events failed for {}: {}",
+                pubkey_hex,
+                e
+            );
+            None
+        }
+    };
+
+    // Best-effort teardown so sockets don't linger.
+    client.shutdown().await;
+
+    result
+}
+
+fn parse_kind0(content: &str) -> Option<ProfileMetadata> {
+    let parsed: Kind0Content = serde_json::from_str(content).ok()?;
+    let display_name = parsed
+        .display_name
+        .and_then(non_empty)
+        .or_else(|| parsed.name.and_then(non_empty));
+    let picture = parsed.picture.and_then(non_empty);
+    if display_name.is_none() && picture.is_none() {
+        return None;
+    }
+    Some(ProfileMetadata {
+        display_name,
+        picture,
+    })
+}
+
+fn non_empty(s: String) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_display_name_preferred_over_name() {
+        let m = parse_kind0(r#"{"name":"short","display_name":"Long Name"}"#).unwrap();
+        assert_eq!(m.display_name.as_deref(), Some("Long Name"));
+        assert_eq!(m.picture, None);
+    }
+
+    #[test]
+    fn falls_back_to_name_when_display_name_missing() {
+        let m = parse_kind0(r#"{"name":"only"}"#).unwrap();
+        assert_eq!(m.display_name.as_deref(), Some("only"));
+    }
+
+    #[test]
+    fn ignores_empty_strings() {
+        let m = parse_kind0(r#"{"name":"","display_name":"  ","picture":""}"#);
+        assert!(m.is_none());
+    }
+
+    #[test]
+    fn extracts_picture() {
+        let m = parse_kind0(r#"{"name":"a","picture":"https://example.com/x.png"}"#).unwrap();
+        assert_eq!(m.picture.as_deref(), Some("https://example.com/x.png"));
+    }
+
+    #[test]
+    fn returns_none_on_bad_json() {
+        assert!(parse_kind0("not json").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Rework the team-invitation email so it mirrors the accept-invite page recipients see when they click through: centred Synvya wordmark, **Team Invitation** heading, white card with the team's avatar + display name, inviter / recipient / expiry line, and a prominent Accept Invitation button.

Solves two issues with the old email:

- Showed a truncated pubkey (`f7ebfcf1…`) instead of the admin's identity when the admin had no `display_name` / `username` set. Now falls back to the admin's **email**.
- Showed the raw team handle (`elcandado`) with no avatar. Now fetches kind-0 for the team's stored key from `BUNKER_RELAYS` and uses the same `display_name` + `picture` the accept page renders, so the two views match.

## Changes

- **New** `api/src/nostr_profile.rs` — `fetch_profile_metadata(pubkey, relays)` with a 3s timeout. Returns `None` on any failure (bad pubkey, unreachable relay, timeout, no kind-0, malformed JSON) so the email still sends with a sensible fallback.
- `api/src/email_service.rs` — extended `EmailSender::send_team_invite_email` to accept `team_picture: Option<&str>`, `expires_at`, and a renamed `inviter_label`; rewrote `team_invite_html` / `team_invite_text` as the card layout. HTML-escapes all interpolated values; avatar URL restricted to http/https.
- `api/src/api/http/teams.rs` — in the invite handler, resolve inviter email, load team key pubkey, call kind-0 fetch, pass real display name / picture / expiry / inviter label. Existing `InvitationListItem` response still uses the previous `resolve_display_name` behaviour.
- `api/src/lib.rs` — exports the new module.

## Fallback behaviour

| Scenario                                          | Email shows                                     |
|---------------------------------------------------|-------------------------------------------------|
| Admin has `display_name` set                      | Display name (unchanged)                        |
| Admin has no display name, has email              | **Admin email** (new)                           |
| Admin has neither                                 | `pubkey[..8]…` (unchanged)                      |
| Team stored-key has kind-0 with `display_name`    | Kind-0 display name                             |
| No kind-0 / relay timeout / no stored key         | `team.name` handle (unchanged)                  |
| Kind-0 has valid http/https `picture`             | Avatar rendered in card                         |
| `picture` missing or non-http                     | Card rendered without avatar (no broken image)  |

## Out of scope

Visual consistency pass for `verification` / `password_reset` / `claim` emails — tracked separately. Those don't have an entity to present, so the card pattern doesn't transfer; a lighter shared header/footer/button treatment can follow.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo check -p keycast_api --features aws` clean
- [x] `cargo clippy -p keycast_api --all-targets -- -D warnings` clean
- [x] `cargo test -p keycast_api --lib` — 62 passed (5 new for the kind-0 parser)
- [ ] Staging smoke test: invite a new email to a team, confirm email shows inviter email, team display name, and avatar
- [ ] Confirm an invitation still goes out if `BUNKER_RELAYS` is briefly unreachable (fallback to DB handle, no avatar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)