### PR TITLE
style: apply cargo fmt

### DIFF
--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -703,8 +703,7 @@ pub async fn invite_user(
             // Best-effort kind-0 fetch so the email can show the team's real display
             // name and avatar (same as the accept page). Falls back to the DB handle.
             let profile = if let Some(ref pk) = team_key_pubkey {
-                let relays =
-                    keycast_core::types::authorization::Authorization::get_bunker_relays();
+                let relays = keycast_core::types::authorization::Authorization::get_bunker_relays();
                 crate::nostr_profile::fetch_profile_metadata(pk, &relays).await
             } else {
                 None

--- a/api/src/email_service.rs
+++ b/api/src/email_service.rs
@@ -481,7 +481,10 @@ impl EmailSender for DevEmailSender {
         if let Ok(mut captured) = self.captured.lock() {
             captured.push(CapturedEmail {
                 to: to_email.to_string(),
-                subject: format!("You've been invited to join {} on Synvya", team_display_name),
+                subject: format!(
+                    "You've been invited to join {} on Synvya",
+                    team_display_name
+                ),
                 verification_url: Some(invite_url.to_string()),
                 reset_url: None,
             });

--- a/api/src/nostr_profile.rs
+++ b/api/src/nostr_profile.rs
@@ -43,7 +43,11 @@ pub async fn fetch_profile_metadata(
     let public_key = match PublicKey::from_hex(pubkey_hex) {
         Ok(pk) => pk,
         Err(e) => {
-            tracing::warn!("fetch_profile_metadata: invalid pubkey {}: {}", pubkey_hex, e);
+            tracing::warn!(
+                "fetch_profile_metadata: invalid pubkey {}: {}",
+                pubkey_hex,
+                e
+            );
             return None;
         }
     };


### PR DESCRIPTION
## Summary

CI on synvya-staging failed the `cargo fmt --all -- --check` step. This applies the exact formatting rustfmt wanted in three files:

- `api/src/api/http/teams.rs` — collapse a `let relays = ...` back onto one line.
- `api/src/email_service.rs` — wrap a long `format!` into multi-line form.
- `api/src/nostr_profile.rs` — wrap a long `tracing::warn!` call.

No behavior changes.

## Test plan

- [ ] `cargo fmt --all -- --check` passes in CI
- [ ] Existing tests stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)