### PR TITLE
chore(fmt): apply cargo fmt to admin.rs claim-email call site

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -733,8 +733,7 @@ pub async fn batch_create_claim_tokens(
             // can show the restaurant's display name + logo on the claim card.
             // Falls back to the plain layout on any failure.
             let relays = keycast_core::types::authorization::Authorization::get_bunker_relays();
-            let profile =
-                crate::nostr_profile::fetch_profile_metadata(&user_pubkey, &relays).await;
+            let profile = crate::nostr_profile::fetch_profile_metadata(&user_pubkey, &relays).await;
             let account_display_name = profile.as_ref().and_then(|p| p.display_name.as_deref());
             let account_picture = profile.as_ref().and_then(|p| p.picture.as_deref());
 


### PR DESCRIPTION
## Summary

CI \`cargo fmt --all -- --check\` failed on synvya-staging after #35 merged. This PR applies the one-line fmt fix rustfmt wanted.

\`\`\`
-            let profile =
-                crate::nostr_profile::fetch_profile_metadata(&user_pubkey, &relays).await;
+            let profile = crate::nostr_profile::fetch_profile_metadata(&user_pubkey, &relays).await;
\`\`\`

## Test plan

- [x] \`cargo fmt --all -- --check\` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)