### PR TITLE
ci(ec2): swap + cargo -j 2 + Docker dep cache for low-mem deploys

### DIFF
--- a/.github/workflows/build-test-push-synvya.yaml
+++ b/.github/workflows/build-test-push-synvya.yaml
@@ -144,6 +144,7 @@ jobs:
               exit 1
             fi
             git pull --ff-only origin synvya-staging
+            bash scripts/ec2-prepare-host.sh
             bash scripts/load-secrets.sh staging
             if [ -n "${{ vars.DISABLE_EMAILS }}" ]; then
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
@@ -152,7 +153,7 @@ jobs:
             docker builder prune -af || true
             docker image prune -af || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
-              build postgres redis migrate keycast
+              build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               up -d postgres redis migrate keycast
             sleep 10
@@ -182,6 +183,7 @@ jobs:
               exit 1
             fi
             git pull --ff-only origin synvya
+            bash scripts/ec2-prepare-host.sh
             bash scripts/load-secrets.sh production
             if [ -n "${{ vars.DISABLE_EMAILS }}" ]; then
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
@@ -190,7 +192,7 @@ jobs:
             docker builder prune -af || true
             docker image prune -af || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
-              build postgres redis migrate keycast
+              build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               up -d postgres redis migrate keycast
             sleep 10
@@ -222,6 +224,9 @@ jobs:
               curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             fi
             source "$HOME/.cargo/env"
+
+            # Ensure swap + cargo jobs limit are in place for the QA build
+            bash /opt/synvya/keycast/scripts/ec2-prepare-host.sh
 
             # Load env for POSTGRES_PASSWORD
             set -a
@@ -300,6 +305,9 @@ jobs:
               curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             fi
             source "$HOME/.cargo/env"
+
+            # Ensure swap + cargo jobs limit are in place for the QA build
+            bash /opt/synvya/keycast/scripts/ec2-prepare-host.sh
 
             # Load env for POSTGRES_PASSWORD
             set -a

--- a/.github/workflows/build-test-push-synvya.yaml
+++ b/.github/workflows/build-test-push-synvya.yaml
@@ -150,8 +150,11 @@ jobs:
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
             fi
             docker system df || true
-            docker builder prune -af || true
-            docker image prune -af || true
+            # Light cleanup: drop dangling images and unreferenced build
+            # cache only. `-a` would wipe referenced layers and force a
+            # cold cargo build of all dependencies on every deploy.
+            docker image prune -f || true
+            docker builder prune -f || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
@@ -189,8 +192,11 @@ jobs:
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
             fi
             docker system df || true
-            docker builder prune -af || true
-            docker image prune -af || true
+            # Light cleanup: drop dangling images and unreferenced build
+            # cache only. `-a` would wipe referenced layers and force a
+            # cold cargo build of all dependencies on every deploy.
+            docker image prune -f || true
+            docker builder prune -f || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 
 ARG CARGO_FEATURES=""
+ARG CARGO_BUILD_JOBS=""
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 RUN if [ -n "$CARGO_FEATURES" ]; then \
       cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,44 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
+# ── Stage A: cache dependency compilation ─────────────────────────────
+# Copy only manifests + any cargo-auto-detected build scripts, then stub
+# every workspace member so dependencies compile without our source.
+# This layer is reused across pushes whenever Cargo.toml/Cargo.lock and
+# the member manifests are unchanged — saving the ~400-crate cold build.
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./api/Cargo.toml ./api/Cargo.toml
+COPY ./api/build.rs ./api/build.rs
+COPY ./core/Cargo.toml ./core/Cargo.toml
+COPY ./signer/Cargo.toml ./signer/Cargo.toml
+COPY ./keycast/Cargo.toml ./keycast/Cargo.toml
+COPY ./cluster-hashring/Cargo.toml ./cluster-hashring/Cargo.toml
+COPY ./tools/loadtest/Cargo.toml ./tools/loadtest/Cargo.toml
+
+RUN mkdir -p api/src core/src signer/src keycast/src cluster-hashring/src tools/loadtest/src && \
+    : > api/src/lib.rs && \
+    : > core/src/lib.rs && \
+    : > signer/src/lib.rs && \
+    : > cluster-hashring/src/lib.rs && \
+    echo 'fn main() {}' > keycast/src/main.rs && \
+    echo 'fn main() {}' > tools/loadtest/src/main.rs
+
+ARG CARGO_FEATURES=""
+ARG CARGO_BUILD_JOBS=""
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+
+RUN if [ -n "$CARGO_FEATURES" ]; then \
+      cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
+    else \
+      cargo build --release --bin keycast; \
+    fi
+
+# ── Stage B: real-source build ────────────────────────────────────────
+# Real sources overwrite stubs; cargo recompiles only the workspace
+# crates (their content hashes changed) and reuses dep .rlibs from
+# Stage A in target/release/deps.
 COPY ./api ./api
 COPY ./signer ./signer
 COPY ./core ./core
@@ -14,12 +52,7 @@ COPY ./keycast ./keycast
 COPY ./cluster-hashring ./cluster-hashring
 COPY ./tools ./tools
 COPY ./database/migrations ./database/migrations
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
 
-ARG CARGO_FEATURES=""
-ARG CARGO_BUILD_JOBS=""
-ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 RUN if [ -n "$CARGO_FEATURES" ]; then \
       cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
     else \

--- a/scripts/ec2-prepare-host.sh
+++ b/scripts/ec2-prepare-host.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Idempotent host prep for low-memory EC2 instances (e.g. t3.medium).
+# Ensures enough swap to survive Rust release builds and constrains host-side
+# cargo to a safe job count. Safe to run on every deploy.
+set -euo pipefail
+
+SWAPFILE="${SWAPFILE:-/swapfile}"
+SWAP_SIZE="${SWAP_SIZE:-4G}"
+CARGO_JOBS="${CARGO_JOBS:-2}"
+
+echo "=== ec2-prepare-host: ensure swap (${SWAP_SIZE} at ${SWAPFILE}) ==="
+if swapon --show=NAME --noheadings | grep -qx "${SWAPFILE}"; then
+  echo "swap already active at ${SWAPFILE}"
+else
+  if [ ! -f "${SWAPFILE}" ]; then
+    sudo fallocate -l "${SWAP_SIZE}" "${SWAPFILE}" || \
+      sudo dd if=/dev/zero of="${SWAPFILE}" bs=1M count=$((${SWAP_SIZE%G} * 1024))
+    sudo chmod 600 "${SWAPFILE}"
+    sudo mkswap "${SWAPFILE}"
+  fi
+  sudo swapon "${SWAPFILE}"
+  if ! grep -qE "^${SWAPFILE}\s" /etc/fstab; then
+    echo "${SWAPFILE} none swap sw 0 0" | sudo tee -a /etc/fstab >/dev/null
+  fi
+  echo "swap enabled at ${SWAPFILE}"
+fi
+
+echo "=== ec2-prepare-host: ensure ~/.cargo/config.toml jobs=${CARGO_JOBS} ==="
+mkdir -p "${HOME}/.cargo"
+CARGO_CFG="${HOME}/.cargo/config.toml"
+if [ ! -f "${CARGO_CFG}" ] || ! grep -qE '^\[build\]' "${CARGO_CFG}"; then
+  cat >> "${CARGO_CFG}" <<EOF
+
+[build]
+jobs = ${CARGO_JOBS}
+EOF
+  echo "wrote [build] jobs=${CARGO_JOBS} to ${CARGO_CFG}"
+else
+  echo "${CARGO_CFG} already has [build] section, leaving as-is"
+fi
+
+echo "=== ec2-prepare-host: memory snapshot ==="
+free -h


### PR DESCRIPTION
## Summary

Two-part fix so the Synvya t3.medium EC2 instances can build Rust reliably and don't recompile every dependency on every push.

### Commit 1 — bake swap + cargo `-j 2` into the workflow

- New `scripts/ec2-prepare-host.sh` — idempotent: ensures a 4 GB `/swapfile` is active + persisted in `/etc/fstab`, and writes `~/.cargo/config.toml` with `[build] jobs = 2` if missing.
- Workflow calls the prep script before `docker compose build` (deploy) and before `cargo test` (QA), in both staging and production paths.
- `--build-arg CARGO_BUILD_JOBS=2` passed to `docker compose build` so the in-container cargo run is also constrained.
- `Dockerfile` accepts `CARGO_BUILD_JOBS` as `ARG`/`ENV`, defaulting to empty (no change for contributors with bigger machines).

### Commit 2 — cache cargo dep compilation in Docker; stop wiping layer cache

- Split `rust-builder` into two cargo invocations:
  - **Stage A** copies only `Cargo.toml` / `Cargo.lock` + each workspace member's manifest, stubs every member's source, and runs `cargo build --release --bin keycast` to compile and cache the ~400 transitive deps.
  - **Stage B** copies real sources (overwriting stubs) and re-runs `cargo build`, which now only recompiles our workspace crates because dep `.rlib` artifacts in `target/release/deps` are already cached.
- Workflow: drop `-a` from `docker builder prune` and `docker image prune`. The `-a` variant deletes referenced build cache and tagged images, which is why every deploy was a cold build. Non-`-a` variants still clean up dangling images and unreferenced build cache.

### Combined effect

- Cold deploys (Cargo.toml/Cargo.lock changed): protected by swap + `-j 2`, no more hangs at random crates.
- Warm deploys (code-only changes): skip the dep compile entirely — only the workspace crates rebuild.

## Test plan

- [ ] Merge → first deploy on staging is a full cold build (Stage A populates dep cache); confirm `ec2-prepare-host.sh` logs `swap enabled at /swapfile`
- [ ] Push a code-only change to staging → confirm Stage A is a Docker cache hit and only Stage B rebuilds
- [ ] Confirm `docker compose build` no longer hangs at `rand` etc. on the t3.medium
- [ ] Confirm QA suite still runs cargo tests successfully
- [ ] Inspect EC2: `swapon --show`, `cat ~/.cargo/config.toml`, `free -h`, `docker system df`