### PR TITLE
Promote synvya-staging to synvya: low-mem EC2 build optimizations

### DIFF
--- a/.github/workflows/build-test-push-synvya.yaml
+++ b/.github/workflows/build-test-push-synvya.yaml
@@ -155,6 +155,10 @@ jobs:
             # cold cargo build of all dependencies on every deploy.
             docker image prune -f || true
             docker builder prune -f || true
+            # Force BuildKit so the Dockerfile's --mount=type=cache works.
+            # Compose v2 enables it by default, but be explicit.
+            export DOCKER_BUILDKIT=1
+            export COMPOSE_DOCKER_CLI_BUILD=1
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
@@ -197,6 +201,10 @@ jobs:
             # cold cargo build of all dependencies on every deploy.
             docker image prune -f || true
             docker builder prune -f || true
+            # Force BuildKit so the Dockerfile's --mount=type=cache works.
+            # Compose v2 enables it by default, but be explicit.
+            export DOCKER_BUILDKIT=1
+            export COMPOSE_DOCKER_CLI_BUILD=1
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \

--- a/.github/workflows/build-test-push-synvya.yaml
+++ b/.github/workflows/build-test-push-synvya.yaml
@@ -144,6 +144,7 @@ jobs:
               exit 1
             fi
             git pull --ff-only origin synvya-staging
+            bash scripts/ec2-prepare-host.sh
             bash scripts/load-secrets.sh staging
             if [ -n "${{ vars.DISABLE_EMAILS }}" ]; then
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
@@ -152,7 +153,7 @@ jobs:
             docker builder prune -af || true
             docker image prune -af || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
-              build postgres redis migrate keycast
+              build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               up -d postgres redis migrate keycast
             sleep 10
@@ -182,6 +183,7 @@ jobs:
               exit 1
             fi
             git pull --ff-only origin synvya
+            bash scripts/ec2-prepare-host.sh
             bash scripts/load-secrets.sh production
             if [ -n "${{ vars.DISABLE_EMAILS }}" ]; then
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
@@ -190,7 +192,7 @@ jobs:
             docker builder prune -af || true
             docker image prune -af || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
-              build postgres redis migrate keycast
+              build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               up -d postgres redis migrate keycast
             sleep 10
@@ -222,6 +224,9 @@ jobs:
               curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             fi
             source "$HOME/.cargo/env"
+
+            # Ensure swap + cargo jobs limit are in place for the QA build
+            bash /opt/synvya/keycast/scripts/ec2-prepare-host.sh
 
             # Load env for POSTGRES_PASSWORD
             set -a
@@ -300,6 +305,9 @@ jobs:
               curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             fi
             source "$HOME/.cargo/env"
+
+            # Ensure swap + cargo jobs limit are in place for the QA build
+            bash /opt/synvya/keycast/scripts/ec2-prepare-host.sh
 
             # Load env for POSTGRES_PASSWORD
             set -a

--- a/.github/workflows/build-test-push-synvya.yaml
+++ b/.github/workflows/build-test-push-synvya.yaml
@@ -150,8 +150,11 @@ jobs:
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
             fi
             docker system df || true
-            docker builder prune -af || true
-            docker image prune -af || true
+            # Light cleanup: drop dangling images and unreferenced build
+            # cache only. `-a` would wipe referenced layers and force a
+            # cold cargo build of all dependencies on every deploy.
+            docker image prune -f || true
+            docker builder prune -f || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
@@ -189,8 +192,11 @@ jobs:
               echo "DISABLE_EMAILS=${{ vars.DISABLE_EMAILS }}" >> /opt/synvya/.env
             fi
             docker system df || true
-            docker builder prune -af || true
-            docker image prune -af || true
+            # Light cleanup: drop dangling images and unreferenced build
+            # cache only. `-a` would wipe referenced layers and force a
+            # cold cargo build of all dependencies on every deploy.
+            docker image prune -f || true
+            docker builder prune -f || true
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \
               build --build-arg CARGO_BUILD_JOBS=2 postgres redis migrate keycast
             docker compose -f docker-compose.synvya.yml --env-file /opt/synvya/.env \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 # Build stage for Rust API
 FROM rust:1.93-slim AS rust-builder
 
@@ -7,44 +8,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-
-# ── Stage A: cache dependency compilation ─────────────────────────────
-# Copy only manifests + any cargo-auto-detected build scripts, then stub
-# every workspace member so dependencies compile without our source.
-# This layer is reused across pushes whenever Cargo.toml/Cargo.lock and
-# the member manifests are unchanged — saving the ~400-crate cold build.
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./api/Cargo.toml ./api/Cargo.toml
-COPY ./api/build.rs ./api/build.rs
-COPY ./core/Cargo.toml ./core/Cargo.toml
-COPY ./signer/Cargo.toml ./signer/Cargo.toml
-COPY ./keycast/Cargo.toml ./keycast/Cargo.toml
-COPY ./cluster-hashring/Cargo.toml ./cluster-hashring/Cargo.toml
-COPY ./tools/loadtest/Cargo.toml ./tools/loadtest/Cargo.toml
-
-RUN mkdir -p api/src core/src signer/src keycast/src cluster-hashring/src tools/loadtest/src && \
-    : > api/src/lib.rs && \
-    : > core/src/lib.rs && \
-    : > signer/src/lib.rs && \
-    : > cluster-hashring/src/lib.rs && \
-    echo 'fn main() {}' > keycast/src/main.rs && \
-    echo 'fn main() {}' > tools/loadtest/src/main.rs
-
-ARG CARGO_FEATURES=""
-ARG CARGO_BUILD_JOBS=""
-ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
-
-RUN if [ -n "$CARGO_FEATURES" ]; then \
-      cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
-    else \
-      cargo build --release --bin keycast; \
-    fi
-
-# ── Stage B: real-source build ────────────────────────────────────────
-# Real sources overwrite stubs; cargo recompiles only the workspace
-# crates (their content hashes changed) and reuses dep .rlibs from
-# Stage A in target/release/deps.
 COPY ./api ./api
 COPY ./signer ./signer
 COPY ./core ./core
@@ -52,13 +15,31 @@ COPY ./keycast ./keycast
 COPY ./cluster-hashring ./cluster-hashring
 COPY ./tools ./tools
 COPY ./database/migrations ./database/migrations
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
 
-RUN if [ -n "$CARGO_FEATURES" ]; then \
+ARG CARGO_FEATURES=""
+ARG CARGO_BUILD_JOBS=""
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+
+# BuildKit cache mounts persist the cargo registry/git index and the
+# target/ directory across builds on the same host. Unchanged crates
+# stay compiled, so warm builds skip the ~400-crate dependency build.
+# Artifacts must be copied out of target/ before the RUN ends because
+# cache mounts are not part of the resulting image layer.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    set -e; \
+    if [ -n "$CARGO_FEATURES" ]; then \
       cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
     else \
       cargo build --release --bin keycast; \
-    fi
-RUN cargo build --release --example migrate-vine-users
+    fi; \
+    cargo build --release --example migrate-vine-users; \
+    mkdir -p /artifacts; \
+    cp target/release/keycast /artifacts/keycast; \
+    cp target/release/examples/migrate-vine-users /artifacts/migrate-vine-users
 
 # Build stage for Bun frontend
 FROM oven/bun:1 AS web-builder
@@ -144,9 +125,11 @@ RUN curl -fsSL https://bun.sh/install | bash
 # Create necessary directories
 RUN mkdir -p /app/database /data
 
-# Copy built artifacts - keycast binary and migration tool
-COPY --from=rust-builder /app/target/release/keycast ./
-COPY --from=rust-builder /app/target/release/examples/migrate-vine-users ./
+# Copy built artifacts - keycast binary and migration tool.
+# Sources are /artifacts/ (not target/) because target/ is a BuildKit
+# cache mount in rust-builder and is not present in its image layer.
+COPY --from=rust-builder /artifacts/keycast ./
+COPY --from=rust-builder /artifacts/migrate-vine-users ./
 COPY --from=web-builder /app/web/build ./web
 COPY --from=web-builder /app/web/package.json ./
 COPY --from=web-builder /app/web/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 
 ARG CARGO_FEATURES=""
+ARG CARGO_BUILD_JOBS=""
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 RUN if [ -n "$CARGO_FEATURES" ]; then \
       cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,44 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
+# ── Stage A: cache dependency compilation ─────────────────────────────
+# Copy only manifests + any cargo-auto-detected build scripts, then stub
+# every workspace member so dependencies compile without our source.
+# This layer is reused across pushes whenever Cargo.toml/Cargo.lock and
+# the member manifests are unchanged — saving the ~400-crate cold build.
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./api/Cargo.toml ./api/Cargo.toml
+COPY ./api/build.rs ./api/build.rs
+COPY ./core/Cargo.toml ./core/Cargo.toml
+COPY ./signer/Cargo.toml ./signer/Cargo.toml
+COPY ./keycast/Cargo.toml ./keycast/Cargo.toml
+COPY ./cluster-hashring/Cargo.toml ./cluster-hashring/Cargo.toml
+COPY ./tools/loadtest/Cargo.toml ./tools/loadtest/Cargo.toml
+
+RUN mkdir -p api/src core/src signer/src keycast/src cluster-hashring/src tools/loadtest/src && \
+    : > api/src/lib.rs && \
+    : > core/src/lib.rs && \
+    : > signer/src/lib.rs && \
+    : > cluster-hashring/src/lib.rs && \
+    echo 'fn main() {}' > keycast/src/main.rs && \
+    echo 'fn main() {}' > tools/loadtest/src/main.rs
+
+ARG CARGO_FEATURES=""
+ARG CARGO_BUILD_JOBS=""
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+
+RUN if [ -n "$CARGO_FEATURES" ]; then \
+      cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
+    else \
+      cargo build --release --bin keycast; \
+    fi
+
+# ── Stage B: real-source build ────────────────────────────────────────
+# Real sources overwrite stubs; cargo recompiles only the workspace
+# crates (their content hashes changed) and reuses dep .rlibs from
+# Stage A in target/release/deps.
 COPY ./api ./api
 COPY ./signer ./signer
 COPY ./core ./core
@@ -14,12 +52,7 @@ COPY ./keycast ./keycast
 COPY ./cluster-hashring ./cluster-hashring
 COPY ./tools ./tools
 COPY ./database/migrations ./database/migrations
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
 
-ARG CARGO_FEATURES=""
-ARG CARGO_BUILD_JOBS=""
-ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 RUN if [ -n "$CARGO_FEATURES" ]; then \
       cargo build --release --bin keycast --features "$CARGO_FEATURES"; \
     else \

--- a/scripts/ec2-prepare-host.sh
+++ b/scripts/ec2-prepare-host.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Idempotent host prep for low-memory EC2 instances (e.g. t3.medium).
+# Ensures enough swap to survive Rust release builds and constrains host-side
+# cargo to a safe job count. Safe to run on every deploy.
+set -euo pipefail
+
+SWAPFILE="${SWAPFILE:-/swapfile}"
+SWAP_SIZE="${SWAP_SIZE:-4G}"
+CARGO_JOBS="${CARGO_JOBS:-2}"
+
+echo "=== ec2-prepare-host: ensure swap (${SWAP_SIZE} at ${SWAPFILE}) ==="
+if swapon --show=NAME --noheadings | grep -qx "${SWAPFILE}"; then
+  echo "swap already active at ${SWAPFILE}"
+else
+  if [ ! -f "${SWAPFILE}" ]; then
+    sudo fallocate -l "${SWAP_SIZE}" "${SWAPFILE}" || \
+      sudo dd if=/dev/zero of="${SWAPFILE}" bs=1M count=$((${SWAP_SIZE%G} * 1024))
+    sudo chmod 600 "${SWAPFILE}"
+    sudo mkswap "${SWAPFILE}"
+  fi
+  sudo swapon "${SWAPFILE}"
+  if ! grep -qE "^${SWAPFILE}\s" /etc/fstab; then
+    echo "${SWAPFILE} none swap sw 0 0" | sudo tee -a /etc/fstab >/dev/null
+  fi
+  echo "swap enabled at ${SWAPFILE}"
+fi
+
+echo "=== ec2-prepare-host: ensure ~/.cargo/config.toml jobs=${CARGO_JOBS} ==="
+mkdir -p "${HOME}/.cargo"
+CARGO_CFG="${HOME}/.cargo/config.toml"
+if [ ! -f "${CARGO_CFG}" ] || ! grep -qE '^\[build\]' "${CARGO_CFG}"; then
+  cat >> "${CARGO_CFG}" <<EOF
+
+[build]
+jobs = ${CARGO_JOBS}
+EOF
+  echo "wrote [build] jobs=${CARGO_JOBS} to ${CARGO_CFG}"
+else
+  echo "${CARGO_CFG} already has [build] section, leaving as-is"
+fi
+
+echo "=== ec2-prepare-host: memory snapshot ==="
+free -h


### PR DESCRIPTION
## Summary

Promotes the build-time memory optimizations validated on staging to production.

### What's in this merge

- **#43** — `ci(ec2): swap + cargo -j 2 + Docker dep cache for low-mem deploys`
  - `scripts/ec2-prepare-host.sh`: idempotent swap (4 GB) + `~/.cargo/config.toml` with `[build] jobs = 2`
  - Workflow calls the prep script before deploy/QA; passes `--build-arg CARGO_BUILD_JOBS=2`
  - Dropped `-a` from `docker builder/image prune` so referenced layers and images survive between deploys
- **#44** — `fix(docker): use BuildKit cache mounts for cargo deps`
  - Replaces broken stub-source pattern with `RUN --mount=type=cache` for `/usr/local/cargo/registry`, `/usr/local/cargo/git`, `/app/target`
  - Artifacts copied out to `/artifacts/` before the cache mount disappears; runtime stage COPYs from there
  - Workflow exports `DOCKER_BUILDKIT=1` and `COMPOSE_DOCKER_CLI_BUILD=1`

### Validated on staging

Staging deploy succeeded after these changes — t3.medium no longer hangs at `rand v0.8.5` or other crates during the cargo release build.

### Self-contained on production EC2

The workflow, prep script, and Dockerfile are all merged together. On the first production deploy:
1. New workflow runs, `git pull` brings the new files onto the prod EC2.
2. `ec2-prepare-host.sh` creates the swapfile + cargo jobs config before any build.
3. Cold cargo build runs under swap + `-j 2` — slower but won't OOM.
4. Cache mounts populate during this cold build; subsequent code-only deploys hit the warm path.

No manual prep on the production host required.

## Test plan

- [ ] Merge → confirm production workflow runs the new \`ec2-prepare-host.sh\` step
- [ ] Watch first production deploy logs for: \`swap enabled at /swapfile\`, \`wrote [build] jobs=2 to ~/.cargo/config.toml\`
- [ ] Confirm cold build completes without hanging on \`rand\` or other crates
- [ ] Push a follow-up trivial change to \`synvya\` → confirm warm build is much faster (cache mount reuse)
- [ ] Confirm production health check (\`curl http://localhost:3000/health\`) passes
- [ ] Inspect production EC2 after deploy: \`swapon --show\`, \`cat ~/.cargo/config.toml\`, \`free -h\`, \`docker system df\`