### PR TITLE
fix(docker): serialize build stages + bump SSH timeout

### DIFF
--- a/.github/workflows/build-test-push-synvya.yaml
+++ b/.github/workflows/build-test-push-synvya.yaml
@@ -134,7 +134,7 @@ jobs:
           host: ${{ secrets.EC2_STAGING_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_STAGING_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -euo pipefail
             cd /opt/synvya/keycast
@@ -180,7 +180,7 @@ jobs:
           host: ${{ secrets.EC2_PRODUCTION_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_PRODUCTION_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -euo pipefail
             cd /opt/synvya/keycast
@@ -226,7 +226,7 @@ jobs:
           host: ${{ secrets.EC2_STAGING_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_STAGING_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -e
 
@@ -307,7 +307,7 @@ jobs:
           host: ${{ secrets.EC2_PRODUCTION_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_PRODUCTION_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -e
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # Build stage for Bun frontend
 FROM oven/bun:1 AS web-builder
 
+# Force serial execution: only start web-builder after rust-builder
+# completes. BuildKit otherwise runs the two stages in parallel, which
+# pushes a small EC2 (e.g. t3.medium) into swap thrash and locks the
+# host. This COPY creates a build-graph dependency on rust-builder.
+COPY --from=rust-builder /artifacts/keycast /tmp/.rust-builder-done
+
 # Install build essentials for native modules
 RUN apt-get update && apt-get install -y \
     python3 \

--- a/scripts/ec2-prepare-host.sh
+++ b/scripts/ec2-prepare-host.sh
@@ -8,6 +8,17 @@ SWAPFILE="${SWAPFILE:-/swapfile}"
 SWAP_SIZE="${SWAP_SIZE:-4G}"
 CARGO_JOBS="${CARGO_JOBS:-2}"
 
+# When invoked under sudo, $HOME points to /root. We want the cargo
+# config to land in the invoking user's home so the workflow (which
+# runs as ec2-user over SSH) reads the same file.
+if [ -n "${SUDO_USER:-}" ] && [ "${SUDO_USER}" != "root" ]; then
+  TARGET_HOME="$(getent passwd "${SUDO_USER}" | cut -d: -f6)"
+  TARGET_USER="${SUDO_USER}"
+else
+  TARGET_HOME="${HOME}"
+  TARGET_USER="$(id -un)"
+fi
+
 echo "=== ec2-prepare-host: ensure swap (${SWAP_SIZE} at ${SWAPFILE}) ==="
 if swapon --show=NAME --noheadings | grep -qx "${SWAPFILE}"; then
   echo "swap already active at ${SWAPFILE}"
@@ -25,9 +36,9 @@ else
   echo "swap enabled at ${SWAPFILE}"
 fi
 
-echo "=== ec2-prepare-host: ensure ~/.cargo/config.toml jobs=${CARGO_JOBS} ==="
-mkdir -p "${HOME}/.cargo"
-CARGO_CFG="${HOME}/.cargo/config.toml"
+echo "=== ec2-prepare-host: ensure ${TARGET_HOME}/.cargo/config.toml jobs=${CARGO_JOBS} ==="
+mkdir -p "${TARGET_HOME}/.cargo"
+CARGO_CFG="${TARGET_HOME}/.cargo/config.toml"
 if [ ! -f "${CARGO_CFG}" ] || ! grep -qE '^\[build\]' "${CARGO_CFG}"; then
   cat >> "${CARGO_CFG}" <<EOF
 
@@ -35,6 +46,11 @@ if [ ! -f "${CARGO_CFG}" ] || ! grep -qE '^\[build\]' "${CARGO_CFG}"; then
 jobs = ${CARGO_JOBS}
 EOF
   echo "wrote [build] jobs=${CARGO_JOBS} to ${CARGO_CFG}"
+  # If we're running under sudo, restore ownership so the invoking
+  # user (and cargo running as that user) can read/write the config.
+  if [ "${TARGET_USER}" != "$(id -un)" ]; then
+    chown -R "${TARGET_USER}:${TARGET_USER}" "${TARGET_HOME}/.cargo"
+  fi
 else
   echo "${CARGO_CFG} already has [build] section, leaving as-is"
 fi


### PR DESCRIPTION
## Why

The cold build on production t3.medium locked the host hard enough that SSH and SSM both became unresponsive. Required a reboot to recover.

Root cause: BuildKit runs independent stages **in parallel** by default. The Dockerfile has \`rust-builder\` and \`web-builder\` as independent stages, so the cold build was running:

- cargo release build with \`-j 2\` (~3 GB RSS)
- bun install + vite build with \`NODE_OPTIONS=--max-old-space-size=2048\` (2 GB)
- ...simultaneously, on a 4 GB instance with 4 GB swap

That blew past available memory + swap and the kernel locked.

## Fix

1. **Serialize the build stages.** Add a no-op \`COPY --from=rust-builder /artifacts/keycast /tmp/.rust-builder-done\` as the first instruction of \`web-builder\`. BuildKit honors the cross-stage dependency and won't start web-builder until rust-builder finishes. Now the two heavy compilers run sequentially, never together.

2. **Bump \`command_timeout\` from 30m to 60m** on all four \`appleboy/ssh-action\` steps. A cold cargo + bun build on t3.medium with \`-j 2\` realistically takes 45-55 min. The previous 30m would kill the SSH session mid-build even on a healthy host.

## After this lands

- Cold build: still ~45-55 min, but stays under the timeout and doesn't OOM the host.
- Warm builds: still fast (cache mounts reused), well under 60m.

## Test plan

- [ ] Production EC2 recovered (manual reboot)
- [ ] Merge → confirm production deploy completes a cold build without locking the host
- [ ] Confirm \`free -h\` and \`swapon --show\` after build show healthy state
- [ ] Push a trivial follow-up commit → confirm warm build is fast
- [ ] Confirm SSH access remains available throughout the build (test from another terminal during deploy)

## Follow-up worth doing

This whole class of problem goes away if we stop building on the production host. Build the image on the GitHub-hosted runner (16 GB RAM) and push to a registry; production just \`docker compose pull && up -d\`. Standard prod deploy pattern. Worth scheduling as the real fix.