### PR TITLE
Promote synvya-staging to synvya: serialize build stages + 60m SSH timeout

### DIFF
--- a/.github/workflows/build-test-push-synvya.yaml
+++ b/.github/workflows/build-test-push-synvya.yaml
@@ -134,7 +134,7 @@ jobs:
           host: ${{ secrets.EC2_STAGING_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_STAGING_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -euo pipefail
             cd /opt/synvya/keycast
@@ -180,7 +180,7 @@ jobs:
           host: ${{ secrets.EC2_PRODUCTION_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_PRODUCTION_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -euo pipefail
             cd /opt/synvya/keycast
@@ -226,7 +226,7 @@ jobs:
           host: ${{ secrets.EC2_STAGING_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_STAGING_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -e
 
@@ -307,7 +307,7 @@ jobs:
           host: ${{ secrets.EC2_PRODUCTION_HOST }}
           username: ec2-user
           key: ${{ secrets.EC2_PRODUCTION_SSH_KEY }}
-          command_timeout: 30m
+          command_timeout: 60m
           script: |
             set -e
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # Build stage for Bun frontend
 FROM oven/bun:1 AS web-builder
 
+# Force serial execution: only start web-builder after rust-builder
+# completes. BuildKit otherwise runs the two stages in parallel, which
+# pushes a small EC2 (e.g. t3.medium) into swap thrash and locks the
+# host. This COPY creates a build-graph dependency on rust-builder.
+COPY --from=rust-builder /artifacts/keycast /tmp/.rust-builder-done
+
 # Install build essentials for native modules
 RUN apt-get update && apt-get install -y \
     python3 \

--- a/scripts/ec2-prepare-host.sh
+++ b/scripts/ec2-prepare-host.sh
@@ -8,6 +8,17 @@ SWAPFILE="${SWAPFILE:-/swapfile}"
 SWAP_SIZE="${SWAP_SIZE:-4G}"
 CARGO_JOBS="${CARGO_JOBS:-2}"
 
+# When invoked under sudo, $HOME points to /root. We want the cargo
+# config to land in the invoking user's home so the workflow (which
+# runs as ec2-user over SSH) reads the same file.
+if [ -n "${SUDO_USER:-}" ] && [ "${SUDO_USER}" != "root" ]; then
+  TARGET_HOME="$(getent passwd "${SUDO_USER}" | cut -d: -f6)"
+  TARGET_USER="${SUDO_USER}"
+else
+  TARGET_HOME="${HOME}"
+  TARGET_USER="$(id -un)"
+fi
+
 echo "=== ec2-prepare-host: ensure swap (${SWAP_SIZE} at ${SWAPFILE}) ==="
 if swapon --show=NAME --noheadings | grep -qx "${SWAPFILE}"; then
   echo "swap already active at ${SWAPFILE}"
@@ -25,9 +36,9 @@ else
   echo "swap enabled at ${SWAPFILE}"
 fi
 
-echo "=== ec2-prepare-host: ensure ~/.cargo/config.toml jobs=${CARGO_JOBS} ==="
-mkdir -p "${HOME}/.cargo"
-CARGO_CFG="${HOME}/.cargo/config.toml"
+echo "=== ec2-prepare-host: ensure ${TARGET_HOME}/.cargo/config.toml jobs=${CARGO_JOBS} ==="
+mkdir -p "${TARGET_HOME}/.cargo"
+CARGO_CFG="${TARGET_HOME}/.cargo/config.toml"
 if [ ! -f "${CARGO_CFG}" ] || ! grep -qE '^\[build\]' "${CARGO_CFG}"; then
   cat >> "${CARGO_CFG}" <<EOF
 
@@ -35,6 +46,11 @@ if [ ! -f "${CARGO_CFG}" ] || ! grep -qE '^\[build\]' "${CARGO_CFG}"; then
 jobs = ${CARGO_JOBS}
 EOF
   echo "wrote [build] jobs=${CARGO_JOBS} to ${CARGO_CFG}"
+  # If we're running under sudo, restore ownership so the invoking
+  # user (and cargo running as that user) can read/write the config.
+  if [ "${TARGET_USER}" != "$(id -un)" ]; then
+    chown -R "${TARGET_USER}:${TARGET_USER}" "${TARGET_HOME}/.cargo"
+  fi
 else
   echo "${CARGO_CFG} already has [build] section, leaving as-is"
 fi


### PR DESCRIPTION
## Summary

Promotes the build serialization fix to production. This is the follow-up to #45 — without these changes, the prod cold build locks the host because BuildKit runs cargo + bun in parallel.

### What's in this merge

- **#46** — \`fix(docker): serialize build stages + bump SSH timeout\`
  - \`COPY --from=rust-builder\` no-op in \`web-builder\` forces BuildKit to run rust then bun sequentially (no more concurrent OOM)
  - \`appleboy/ssh-action\` \`command_timeout\` raised from 30m to 60m on all four deploy/QA steps
- **\`f756f50\`** — \`fix(prep): write cargo config to invoking user's home, not /root\`
  - \`ec2-prepare-host.sh\` now detects \`SUDO_USER\` and writes \`~/.cargo/config.toml\` to the right home, then chowns it back

### Validated on staging

Staging redeploy completed successfully with the serialize fix.

### Production state

The prod EC2 has been manually prepared (swap active, cargo jobs config in place, repo synced) so the next deploy starts from a healthy baseline.

## Test plan

- [ ] Merge → confirm prod workflow runs the new serialized build (rust-builder completes before web-builder starts)
- [ ] Confirm cold build fits inside 60m timeout
- [ ] SSH into prod from another terminal during the build to confirm host stays responsive
- [ ] Confirm \`docker ps\` shows new keycast image healthy after deploy
- [ ] Push a trivial follow-up commit → confirm warm build is fast (cache mounts populated)

## Follow-up worth doing

The robust fix for low-mem prod is to stop building on the prod host: build once on GitHub Actions (16 GB RAM), push image to a registry, prod just \`docker compose pull && up -d\`. Worth scheduling.