### PR TITLE
fix(web): make DISABLE_WEB_UI actually block the SvelteKit login UI

### DIFF
--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -774,22 +774,48 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
             }
         };
 
-        let app = app.route("/verify-email", axum::routing::get(verify_email_handler));
+        // SvelteKit entry points must redirect, not serve the SPA. Without
+        // explicit routes, the ServeDir fallback below would expose the login
+        // page anyway: `/` resolves to `index.html` via
+        // `append_index_html_on_directories`, and `/index.html` is a real file
+        // in the build output.
+        let redirect_url_for_routes = redirect_url.clone();
+        let redirect_handler = axum::routing::get(move || {
+            let redirect_url = redirect_url_for_routes.clone();
+            async move {
+                match redirect_url {
+                    Some(url) => axum::response::Redirect::temporary(&url).into_response(),
+                    None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+                }
+            }
+        });
+
+        let app = app
+            .route("/", redirect_handler.clone())
+            .route("/index.html", redirect_handler)
+            .route("/verify-email", axum::routing::get(verify_email_handler));
 
         // Serve SvelteKit static assets (/_app/*, favicon, logos) needed by the
-        // verify-email page; unmatched routes redirect to WEB_UI_REDIRECT_URL.
+        // verify-email page. Unmatched routes redirect to WEB_UI_REDIRECT_URL.
+        // `append_index_html_on_directories(false)` prevents ServeDir from
+        // silently serving build/index.html for any directory-style request
+        // beyond `/` (which is already routed explicitly above).
         let redirect_url_for_fallback = redirect_url.clone();
-        app.fallback_service(ServeDir::new(&web_build_dir).fallback(axum::routing::any(
-            move || {
-                let redirect_url = redirect_url_for_fallback.clone();
-                async move {
-                    match redirect_url {
-                        Some(url) => axum::response::Redirect::temporary(&url).into_response(),
-                        None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+        app.fallback_service(
+            ServeDir::new(&web_build_dir)
+                .append_index_html_on_directories(false)
+                .fallback(axum::routing::any(move || {
+                    let redirect_url = redirect_url_for_fallback.clone();
+                    async move {
+                        match redirect_url {
+                            Some(url) => {
+                                axum::response::Redirect::temporary(&url).into_response()
+                            }
+                            None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+                        }
                     }
-                }
-            },
-        )))
+                })),
+        )
     } else {
         // SvelteKit frontend - explicitly handle root and index.html with injection
         // This ensures index.html always goes through injection, not served as static file


### PR DESCRIPTION
## Summary

- `DISABLE_WEB_UI=true` is meant to keep the keycast SvelteKit UI off public auth domains (Synvya admins use `systemtools` + the API, not a keycast browser session).
- It wasn't doing that: `https://auth.staging.synvya.com/` still rendered the login page, and the JS bundle then tried to call `http://localhost:3000/api/auth/login` because runtime env injection was being bypassed.
- Root cause is in [main.rs:752-792](keycast/src/main.rs): the fallback `ServeDir` defaults to `append_index_html_on_directories(true)`, so `/` resolved to `build/index.html`. `/index.html` was reachable directly as a real file in the build output. Both bypass the redirect and `inject_runtime_env`.
- Fix: route `/` and `/index.html` explicitly to the existing redirect/404 handler, and disable `append_index_html_on_directories` on the fallback `ServeDir` so unknown paths fall through cleanly. `/verify-email` and `/_app/*` carve-outs unchanged.

After this change, with `DISABLE_WEB_UI=true` and `WEB_UI_REDIRECT_URL=https://www.synvya.com`:

| Path | Result |
| --- | --- |
| `/`, `/index.html`, `/login`, `/register`, `/admin`, etc. | 307 → `https://www.synvya.com` |
| `/verify-email` | served (with `__ENV__` injection) |
| `/_app/*`, favicon, logos | served |
| `/api/*`, `/api/oauth/authorize`, `/.well-known/*`, `/health*` | unchanged |

systemtools' admin login flow (`KeycastClient.login` → `createBunker` → NIP-46) is unaffected — it only uses `/api/*`.

## Test plan

- [x] `cargo check -p keycast --bin keycast` passes
- [x] `cargo test -p keycast` — all 7 unit tests pass (no regressions in `inject_runtime_env` / `origin_is_allowed`)
- [ ] Deploy to staging EC2 and confirm:
  - `curl -sI https://auth.staging.synvya.com/` returns 307 with `location: https://www.synvya.com`
  - `curl -sI https://auth.staging.synvya.com/index.html` returns 307
  - `curl -sI https://auth.staging.synvya.com/api/health` (or equivalent) still returns 200
  - `curl -s https://auth.staging.synvya.com/verify-email | grep __ENV__` shows the injected runtime env
- [ ] systemtools sign-in (email/password against keycast) still works end-to-end on staging