### PR TITLE
style: rustfmt fix in DISABLE_WEB_UI fallback handler

### DIFF
--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -808,9 +808,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
                     let redirect_url = redirect_url_for_fallback.clone();
                     async move {
                         match redirect_url {
-                            Some(url) => {
-                                axum::response::Redirect::temporary(&url).into_response()
-                            }
+                            Some(url) => axum::response::Redirect::temporary(&url).into_response(),
                             None => (StatusCode::NOT_FOUND, "Not found").into_response(),
                         }
                     }


### PR DESCRIPTION
## Summary

- Follow-up to [#48](https://github.com/Synvya/keycast/pull/48). The CI `cargo fmt --all -- --check` job failed on the merged commit because the match arm in the new fallback handler was hand-formatted across multiple lines.
- Collapse `Some(url) => { Redirect::temporary(&url).into_response() }` back to a single line, matching what rustfmt wants.

No behavior change — purely a formatting fix.

## Test plan

- [x] `cargo fmt --all -- --check` exits 0 locally