### PR TITLE
feat(synvya): NIP-98 service-auth path on admin routes

### DIFF
--- a/api/src/api/extractors.rs
+++ b/api/src/api/extractors.rs
@@ -15,6 +15,12 @@ pub struct AuthError {
     message: String,
 }
 
+impl AuthError {
+    pub fn new(status: StatusCode, message: String) -> Self {
+        Self { status, message }
+    }
+}
+
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         let body = serde_json::json!({ "error": self.message });
@@ -42,6 +48,13 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let path = parts.uri.path();
+
+        // Try 0: NIP-98 service-auth (Authorization: Nostr <base64>).
+        // Exclusive — if the header is present, this path either succeeds
+        // or the request is rejected. No fall-through to Bearer/cookie.
+        if let Some(result) = crate::api::nip98_extractor::try_authenticate_nip98(parts).await {
+            return result;
+        }
 
         // Try 1: UCAN Bearer Token
         if let Some(auth_header) = parts.headers.get("Authorization") {

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod extractors;
 pub mod http;
+pub mod nip98_extractor;
 pub mod tenant;
 pub mod types;

--- a/api/src/api/nip98_extractor.rs
+++ b/api/src/api/nip98_extractor.rs
@@ -1,0 +1,310 @@
+// ABOUTME: NIP-98 service-auth path for admin routes
+// ABOUTME: Verifies Authorization: Nostr <base64> envelopes, resolves admin_role, anti-replay via Redis
+
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use base64::prelude::*;
+use nostr_sdk::{Event, JsonUtil};
+
+use crate::api::extractors::{AuthError, UcanAuth};
+use crate::api::http::admin::{is_full_admin, is_support_admin};
+use crate::nip98;
+
+/// TTL for anti-replay records in Redis. Slightly longer than the 60s
+/// `created_at` tolerance window so the replay record outlives any envelope
+/// that could still be considered fresh.
+const REPLAY_TTL_SECONDS: u64 = 120;
+
+/// Redis key prefix for replay protection records.
+const REPLAY_KEY_PREFIX: &str = "nip98_replay";
+
+/// Try to authenticate via the NIP-98 service-auth path.
+///
+/// Returns:
+/// - `None` if the request does not carry an `Authorization: Nostr ...` header
+///   (caller should fall through to the cookie path).
+/// - `Some(Ok(UcanAuth))` if the envelope verifies and resolves to an
+///   `admin_role` (which may itself be `None` if the pubkey is neither full
+///   nor support admin).
+/// - `Some(Err(AuthError))` if the header is present but verification fails.
+///   The NIP-98 path is exclusive once the header is present — the caller
+///   MUST NOT fall through to the cookie path on this error.
+pub async fn try_authenticate_nip98(parts: &Parts) -> Option<Result<UcanAuth, AuthError>> {
+    let auth_header_str = parts
+        .headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())?;
+
+    if !auth_header_str.starts_with("Nostr ") {
+        return None;
+    }
+
+    Some(authenticate_nip98(parts, auth_header_str).await)
+}
+
+async fn authenticate_nip98(parts: &Parts, auth_header: &str) -> Result<UcanAuth, AuthError> {
+    let path = parts.uri.path().to_string();
+
+    let Some(expected_url) = build_expected_url(parts) else {
+        tracing::warn!(
+            "NIP-98 service-auth: missing Host / X-Forwarded-Host (path: {})",
+            path
+        );
+        return Err(unauthorized());
+    };
+
+    let method = parts.method.as_str();
+
+    let validated =
+        nip98::extract_and_validate(auth_header, &expected_url, method).map_err(|e| {
+            tracing::warn!(
+                "NIP-98 service-auth verification failed (path: {}): {}",
+                path,
+                e
+            );
+            unauthorized()
+        })?;
+
+    let pubkey_hex = validated.pubkey.to_hex();
+
+    let event_id = parse_event_id(auth_header).map_err(|e| {
+        // Should not happen — extract_and_validate already parsed the same bytes.
+        tracing::warn!(
+            "NIP-98 service-auth: failed to parse event id for replay check: {}",
+            e
+        );
+        unauthorized()
+    })?;
+
+    check_replay(&event_id).await?;
+
+    let probe = UcanAuth {
+        pubkey: pubkey_hex.clone(),
+        admin_role: None,
+    };
+    let admin_role = if is_full_admin(&probe) {
+        Some("full".to_string())
+    } else if is_support_admin(&probe).await {
+        Some("support".to_string())
+    } else {
+        None
+    };
+
+    let pubkey_short = pubkey_hex.get(..8).unwrap_or(&pubkey_hex);
+    tracing::debug!(
+        "NIP-98 service-auth: authenticated pubkey={} admin_role={:?} path={}",
+        pubkey_short,
+        admin_role,
+        path
+    );
+
+    Ok(UcanAuth {
+        pubkey: pubkey_hex,
+        admin_role,
+    })
+}
+
+/// Reconstruct the URL the client signed. Trusts `X-Forwarded-Proto` and
+/// `X-Forwarded-Host` set by the load balancer (Cloud Run / ALB) so that
+/// HTTPS-signed envelopes verify even though the inbound request to the app
+/// arrives as HTTP.
+fn build_expected_url(parts: &Parts) -> Option<String> {
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str().to_string())
+        .unwrap_or_else(|| parts.uri.path().to_string());
+
+    let host = parts
+        .headers
+        .get("x-forwarded-host")
+        .or_else(|| parts.headers.get("host"))
+        .and_then(|v| v.to_str().ok())?;
+
+    let proto = parts
+        .headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_else(|| {
+            if host.contains(":443") || !host.contains(':') {
+                "https"
+            } else {
+                "http"
+            }
+        });
+
+    Some(format!("{}://{}{}", proto, host, path_and_query))
+}
+
+/// Parse the event id from a NIP-98 Authorization header.
+fn parse_event_id(auth_header: &str) -> Result<String, String> {
+    let base64_str = auth_header
+        .strip_prefix("Nostr ")
+        .ok_or_else(|| "missing Nostr prefix".to_string())?
+        .trim();
+    let json_bytes = BASE64_STANDARD
+        .decode(base64_str)
+        .map_err(|e| format!("base64: {}", e))?;
+    let event = Event::from_json(&json_bytes).map_err(|e| format!("json: {}", e))?;
+    Ok(event.id.to_hex())
+}
+
+/// Check Redis for envelope replay. Fail-closed on Redis errors — service
+/// auth resolves to full-admin authority for `ALLOWED_PUBKEYS` callers, so
+/// fail-open here would let a captured envelope be reused during an outage.
+async fn check_replay(event_id: &str) -> Result<(), AuthError> {
+    let state = crate::state::get_keycast_state().map_err(|e| {
+        tracing::error!("NIP-98 anti-replay: keycast state unavailable: {:?}", e);
+        service_unavailable()
+    })?;
+
+    let Some(redis) = state.redis.as_ref() else {
+        tracing::error!(
+            "NIP-98 anti-replay: Redis not configured — cannot enforce replay protection"
+        );
+        return Err(service_unavailable());
+    };
+
+    let key = format!("{}:{}", REPLAY_KEY_PREFIX, event_id);
+
+    match redis.set_nx_ex(&key, "1", REPLAY_TTL_SECONDS).await {
+        Ok(true) => Ok(()),
+        Ok(false) => {
+            tracing::warn!(
+                "NIP-98 anti-replay: rejecting replayed envelope id={}",
+                event_id
+            );
+            Err(unauthorized())
+        }
+        Err(e) => {
+            tracing::error!("NIP-98 anti-replay: Redis SET NX failed: {}", e);
+            Err(service_unavailable())
+        }
+    }
+}
+
+fn unauthorized() -> AuthError {
+    AuthError::new(StatusCode::UNAUTHORIZED, "unauthorized".to_string())
+}
+
+fn service_unavailable() -> AuthError {
+    AuthError::new(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "service temporarily unavailable".to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue, Method, Request, Uri};
+    use nostr_sdk::{EventBuilder, Keys, Kind, Tag};
+
+    fn parts_from(uri: &str, method: Method, headers: Vec<(&str, &str)>) -> Parts {
+        let mut req = Request::builder()
+            .method(method)
+            .uri(uri.parse::<Uri>().unwrap())
+            .body(())
+            .unwrap();
+        let hdrs: &mut HeaderMap = req.headers_mut();
+        for (k, v) in headers {
+            hdrs.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        req.into_parts().0
+    }
+
+    #[test]
+    fn build_expected_url_uses_forwarded_proto_and_host() {
+        let parts = parts_from(
+            "/api/admin/support-admins?x=1",
+            Method::POST,
+            vec![
+                ("X-Forwarded-Proto", "https"),
+                ("X-Forwarded-Host", "auth.synvya.com"),
+                ("Host", "internal-host"),
+            ],
+        );
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(url, "https://auth.synvya.com/api/admin/support-admins?x=1");
+    }
+
+    #[test]
+    fn build_expected_url_falls_back_to_host_header() {
+        let parts = parts_from(
+            "/api/admin/support-admins",
+            Method::POST,
+            vec![("Host", "auth.synvya.com")],
+        );
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(url, "https://auth.synvya.com/api/admin/support-admins");
+    }
+
+    #[test]
+    fn build_expected_url_returns_none_without_host() {
+        let parts = parts_from("/api/admin/support-admins", Method::POST, vec![]);
+        assert!(build_expected_url(&parts).is_none());
+    }
+
+    #[test]
+    fn build_expected_url_preserves_query_string() {
+        let parts = parts_from(
+            "/api/admin/user-lookup?q=alice%40example.com",
+            Method::GET,
+            vec![("Host", "auth.synvya.com")],
+        );
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(
+            url,
+            "https://auth.synvya.com/api/admin/user-lookup?q=alice%40example.com"
+        );
+    }
+
+    /// Build a NIP-98 Authorization header for the given keys/url/method.
+    async fn make_header(keys: &Keys, url: &str, method: &str) -> String {
+        let event = EventBuilder::new(Kind::HttpAuth, "")
+            .tags([
+                Tag::parse(["u", url]).unwrap(),
+                Tag::parse(["method", method]).unwrap(),
+            ])
+            .sign(keys)
+            .await
+            .unwrap();
+        format!("Nostr {}", BASE64_STANDARD.encode(event.as_json()))
+    }
+
+    #[tokio::test]
+    async fn try_authenticate_returns_none_when_header_absent() {
+        let parts = parts_from(
+            "/api/admin/support-admins",
+            Method::POST,
+            vec![("Host", "auth.synvya.com")],
+        );
+        let result = try_authenticate_nip98(&parts).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn try_authenticate_returns_none_for_bearer_header() {
+        let parts = parts_from(
+            "/api/admin/support-admins",
+            Method::POST,
+            vec![
+                ("Host", "auth.synvya.com"),
+                ("Authorization", "Bearer some-token"),
+            ],
+        );
+        let result = try_authenticate_nip98(&parts).await;
+        assert!(result.is_none(), "Bearer header must fall through");
+    }
+
+    #[tokio::test]
+    async fn parse_event_id_round_trips() {
+        let keys = Keys::generate();
+        let header = make_header(&keys, "https://auth.synvya.com/x", "POST").await;
+        let id = parse_event_id(&header).expect("event id parse");
+        assert_eq!(id.len(), 64, "event id is 32 bytes hex");
+    }
+}

--- a/api/src/redis.rs
+++ b/api/src/redis.rs
@@ -266,6 +266,40 @@ impl PrefixedRedis {
         })
         .await
     }
+
+    /// Atomically `SET key value NX EX ttl_seconds`.
+    ///
+    /// Returns `Ok(true)` if the key was set (it did not previously exist).
+    /// Returns `Ok(false)` if the key already existed (NX condition failed).
+    ///
+    /// Used for anti-replay protection: a unique token is `set_nx_ex`'d on
+    /// first sight; a duplicate within the TTL returns `false`.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if Redis operation fails or connection refresh fails.
+    pub async fn set_nx_ex(&self, key: &str, value: &str, ttl_seconds: u64) -> RedisResult<bool> {
+        let prefixed = self.prefixed_key(key).into_owned();
+        let value = value.to_string();
+        self.with_refresh(|mut conn| {
+            let key = prefixed.clone();
+            let val = value.clone();
+            async move {
+                // SET key value NX EX ttl returns "OK" (bulk string) if set,
+                // or nil if NX failed. Map to bool.
+                let result: Option<String> = redis::cmd("SET")
+                    .arg(key)
+                    .arg(val)
+                    .arg("NX")
+                    .arg("EX")
+                    .arg(ttl_seconds)
+                    .query_async(&mut conn)
+                    .await?;
+                Ok(result.is_some())
+            }
+        })
+        .await
+    }
 }
 
 #[cfg(test)]

--- a/docs/synvya/keycast-service-auth.md
+++ b/docs/synvya/keycast-service-auth.md
@@ -38,10 +38,11 @@ New path:       NIP-98 header → UcanAuth { pubkey, admin_role }
 
 The composition order:
 
-1. If `Authorization: Nostr <base64-event>` is present, attempt NIP-98 verification.
-2. If verification succeeds, resolve `admin_role` from `ALLOWED_PUBKEYS` / `support_admins` Redis set, and return `UcanAuth`.
-3. Otherwise, fall back to the existing UCAN cookie path.
-4. If neither resolves, return 401.
+1. If `Authorization: Nostr <base64-event>` is present, the NIP-98 path is **exclusive**: verify the envelope and either resolve `admin_role` from `ALLOWED_PUBKEYS` / `support_admins` Redis set and return `UcanAuth`, or return 401. Do **not** fall through to the cookie path on NIP-98 failure.
+2. If the header is absent, fall back to the existing UCAN cookie path.
+3. If neither resolves, return 401.
+
+The exclusivity rule in step 1 is deliberate. A caller that sets `Authorization: Nostr ...` has explicitly declared "I am a service signing with NIP-98." Silently retrying as a cookie request on verification failure would hide NIP-98 errors from operators and could resolve the request under a different identity if a cookie happens to be in scope (dev sessions, shared browsers, CI). There is no legitimate caller that needs both paths tried in sequence.
 
 ## 3. NIP-98 Verification
 
@@ -79,7 +80,11 @@ The Synvya server signs every admin call with a fresh `created_at`. To prevent e
 - Store the id in Redis with a TTL slightly longer than the `created_at` tolerance window (e.g. `EXPIRE 120` seconds).
 - On each verification, `SET NX` on the id key. If the key already existed, reject as a replay.
 
-If Redis is unavailable, the verification falls back to "accept" — no replay protection, but the request still proceeds. This matches how `is_support_admin()` already handles Redis outages: log a warning, do not block.
+If Redis is unavailable, the anti-replay check **fails closed**: return 503 with a generic "service temporarily unavailable" body and log a warning. The verification does not proceed.
+
+Rationale: anti-replay is part of the authentication itself, not a downstream role check. Failing open would let a captured envelope be reused for the duration of a Redis outage, expanding the replay window from the ±60s `created_at` tolerance to "as long as Redis is down." Because NIP-98 service auth resolves to full-admin authority for the systemtools service pubkey (§4, §7), a replayed envelope is a high-impact credential. Fail-closed is the correct trade — service-to-service callers retry naturally on 503; brief Redis blips do not compromise auth.
+
+Note: this differs from how `is_support_admin()` handles Redis outages (it logs and returns false, treating the caller as non-support). That fallback is safe because the request is already authenticated and the failure mode is *capability downgrade*. Anti-replay sits earlier in the pipeline and a fallback there is *authentication weakening*.
 
 ## 6. Performance
 
@@ -112,8 +117,9 @@ The server pubkey (derived from `SERVER_BUNKER_CLIENT_PRIVATE_KEY`) must be in `
   - [ ] Stale `created_at` → 401.
   - [ ] Tampered signature → 401.
   - [ ] Replayed envelope (same id within TTL) → 401.
-  - [ ] Redis unavailable during anti-replay check → request proceeds (warning logged).
+  - [ ] Redis unavailable during anti-replay check → 503, request rejected (warning logged).
   - [ ] UCAN cookie still works on routes that previously accepted it.
+  - [ ] Request with both an invalid `Authorization: Nostr ...` header and a valid UCAN cookie → 401 (NIP-98 path is exclusive when the header is present).
 
 ## 9. Out of Scope
 


### PR DESCRIPTION
## Summary

Implements [keycast-service-auth.md](docs/synvya/keycast-service-auth.md): admin routes now accept `Authorization: Nostr <base64(kind:27235 event)>` envelopes as an alternative to the UCAN cookie. Service callers (e.g. systemtools backend) can authenticate to admin endpoints without holding a session.

## Design choices (per spec)

- **NIP-98 path is exclusive when the header is present.** If the envelope fails verification, return 401 — do not fall through to the cookie path. Prevents silent identity drift if a service caller's envelope is malformed but a cookie happens to be in scope.
- **Anti-replay fails closed (503) on Redis outage.** Service auth resolves to full-admin authority for `ALLOWED_PUBKEYS` callers, so fail-open would let captured envelopes be reused during an outage. Service-to-service callers retry naturally on 503.

## Implementation

- New module `api/src/api/nip98_extractor.rs` with the verification flow.
- Wired into `UcanAuth::from_request_parts` ahead of the Bearer/cookie paths.
- New `PrefixedRedis::set_nx_ex` method for atomic `SET NX EX` (anti-replay store).
- `AuthError::new()` constructor exposed so the new extractor can return 401/503.
- URL reconstruction trusts `X-Forwarded-Proto` / `X-Forwarded-Host` so HTTPS-signed envelopes verify behind Cloud Run / ALB.
- Includes the spec doc updates discussed in review (exclusivity rule + 503 fail-closed).

## Test plan

- [x] `cargo build -p keycast_api`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p keycast_api --lib` — 69 tests pass (7 new for the extractor)
- [ ] Integration tests requiring PostgreSQL — pre-existing infra gap; not exercised in this branch
- [ ] End-to-end check from systemtools side once it lands (separate repo)

## Out of scope

- Consumer endpoints (`add_support_admin`, `preload_user`, etc.) already exist; this PR only adds the auth path they will use.
- Per-call human-attribution headers (`X-Acting-As`) — deferred per spec §9.