### PR TITLE
fix(nip98-extractor): use OriginalUri so /api prefix isn't stripped

### DIFF
--- a/api/src/api/nip98_extractor.rs
+++ b/api/src/api/nip98_extractor.rs
@@ -1,6 +1,7 @@
 // ABOUTME: NIP-98 service-auth path for admin routes
 // ABOUTME: Verifies Authorization: Nostr <base64> envelopes, resolves admin_role, anti-replay via Redis
 
+use axum::extract::OriginalUri;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 use base64::prelude::*;
@@ -108,12 +109,24 @@ async fn authenticate_nip98(parts: &Parts, auth_header: &str) -> Result<UcanAuth
 /// `X-Forwarded-Host` set by the load balancer (Cloud Run / ALB) so that
 /// HTTPS-signed envelopes verify even though the inbound request to the app
 /// arrives as HTTP.
+///
+/// Reads the path from `OriginalUri` (axum populates it as a request
+/// extension before nesting strips prefixes) so that requests arriving via
+/// `Router::nest("/api", ...)` are reconstructed with the `/api/` prefix
+/// the client actually signed. Falls back to `parts.uri` when no
+/// `OriginalUri` extension is present (e.g. unit tests built from a bare
+/// `Request`).
 fn build_expected_url(parts: &Parts) -> Option<String> {
-    let path_and_query = parts
-        .uri
+    let original_uri = parts
+        .extensions
+        .get::<OriginalUri>()
+        .map(|o| &o.0)
+        .unwrap_or(&parts.uri);
+
+    let path_and_query = original_uri
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
-        .unwrap_or_else(|| parts.uri.path().to_string());
+        .unwrap_or_else(|| original_uri.path().to_string());
 
     let host = parts
         .headers
@@ -260,6 +273,26 @@ mod tests {
             url,
             "https://auth.synvya.com/api/admin/user-lookup?q=alice%40example.com"
         );
+    }
+
+    /// When the request was routed through `Router::nest("/api", ...)`, axum
+    /// strips the `/api` prefix from `parts.uri` but stores the original path
+    /// in the `OriginalUri` extension. The extractor must read from the
+    /// extension so the reconstructed URL matches what the client actually
+    /// signed (including the `/api/` prefix).
+    #[test]
+    fn build_expected_url_uses_original_uri_when_nested() {
+        let mut parts = parts_from(
+            // post-strip path that axum sees inside the nested router
+            "/admin/status",
+            Method::GET,
+            vec![("Host", "auth.synvya.com")],
+        );
+        parts
+            .extensions
+            .insert(OriginalUri("/api/admin/status".parse::<Uri>().unwrap()));
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(url, "https://auth.synvya.com/api/admin/status");
     }
 
     /// Build a NIP-98 Authorization header for the given keys/url/method.


### PR DESCRIPTION
## Summary

- `nip98_extractor::build_expected_url` reconstructed the request URL from `parts.uri`, but the admin router is mounted via `Router::nest(\"/api\", ...)`, so axum strips `/api` before the extractor sees the request. A NIP-98 caller signs the URL it actually hits (`http://host/api/admin/status`) but the extractor was rebuilding it as `http://host/admin/status`, rejecting every service-auth request with a URL mismatch.
- Fix: read the path from the `OriginalUri` request extension (axum populates it before nesting strips prefixes), falling back to `parts.uri` when the extension is absent (unit tests built from a bare `Request`).
- Existing NIP-98 admin login in `auth.rs::nostr_auth_login` already hardcodes `/api/auth/login`, which is why login worked but service auth on other admin routes did not. The two paths must agree on "NIP-98 `u` tag = the URL the caller actually hit".

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p keycast_api` green
- [x] `cargo test -p keycast_api --lib api::nip98_extractor` — all 8 tests pass, including the new `build_expected_url_uses_original_uri_when_nested` that simulates the nested case by inserting an `OriginalUri` extension explicitly
- [ ] Synvya server's keycast e2e — `resolves NIP-98 service auth to admin_role:'full'` should pass with `{ is_admin: true, role: \"full\" }` after this lands and Keycast is redeployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)