### PR TITLE
feat(claim): pre-fill email and rebrand claim pages for Synvya Admin

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -725,7 +725,18 @@ pub async fn batch_create_claim_tokens(
             }
         };
 
-        let claim_url = format!("{}/api/claim?token={}", app_url, token);
+        // Pre-fill the recipient's email on the claim form when we know it.
+        // Convenience only — the user can edit it, and claim_post does not
+        // enforce a match. See docs/synvya/admin-user-provisioning.md.
+        let claim_url = match &req.delivery_email {
+            Some(email) => format!(
+                "{}/api/claim?token={}&email={}",
+                app_url,
+                token,
+                urlencoding::encode(email)
+            ),
+            None => format!("{}/api/claim?token={}", app_url, token),
+        };
 
         // Send email if requested
         if let (Some(email), Some(svc)) = (&req.delivery_email, &email_service) {

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -75,7 +75,7 @@ pub async fn claim_get(
     let prefill_email = params.email.as_deref().unwrap_or("");
 
     let html = format!(
-        r#"<!DOCTYPE html>
+        r##"<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -101,6 +101,12 @@ pub async fn claim_get(
             max-width: 400px;
             width: 100%;
             box-shadow: 0 8px 32px rgba(39, 197, 139, 0.08);
+        }}
+        .logo {{
+            width: 140px;
+            height: auto;
+            display: block;
+            margin: 0 auto 24px;
         }}
         h1 {{
             margin: 0 0 8px 0;
@@ -193,6 +199,16 @@ pub async fn claim_get(
 </head>
 <body>
     <div class="container">
+        <svg class="logo" viewBox="0 0 240 100" xmlns="http://www.w3.org/2000/svg" aria-label="Synvya">
+            <g fill="#1DB054">
+                <rect x="20" y="60" width="45" height="6" rx="3" />
+                <path d="M25 58 C25 35 60 35 60 58 Z" />
+                <circle cx="42.5" cy="36" r="3" />
+                <path d="M68 48 L78 58 L68 68 V62 H58 V54 H68 V48 Z" />
+            </g>
+            <text x="90" y="62" font-family="Arial, sans-serif" font-size="42" fill="#1DB054" font-weight="400">Synvya</text>
+        </svg>
+
         <h1>Claim Your Account</h1>
         <p class="welcome">Set up your login credentials to access your account.</p>
 
@@ -242,7 +258,7 @@ pub async fn claim_get(
         }}
     </script>
 </body>
-</html>"#,
+</html>"##,
         display_name = html_escape(&display_name_str),
         username = html_escape(&username_str),
         token = html_escape(&params.token),
@@ -358,9 +374,16 @@ pub async fn claim_post(
 
     let display_name_str = display_name.unwrap_or_else(|| username.clone().unwrap_or_default());
 
-    // Show success page with app download instructions
+    // Where to send the recipient after they've claimed. Synvya admin onboarding
+    // is the only flow that hits this success page today (Vine import is legacy).
+    // Set in scripts/load-secrets.sh per environment; safe default keeps the
+    // page valid in dev / unset configurations.
+    let admin_base_url =
+        std::env::var("ADMIN_BASE_URL").unwrap_or_else(|_| "https://admin.synvya.com".to_string());
+
+    // Show success page directing the new admin to Synvya Admin.
     let html = format!(
-        r#"<!DOCTYPE html>
+        r##"<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -388,6 +411,12 @@ pub async fn claim_post(
             text-align: center;
             box-shadow: 0 8px 32px rgba(39, 197, 139, 0.08);
         }}
+        .logo {{
+            width: 140px;
+            height: auto;
+            display: block;
+            margin: 0 auto 28px;
+        }}
         .checkmark {{
             width: 56px;
             height: 56px;
@@ -411,65 +440,6 @@ pub async fn claim_post(
             margin: 0 0 28px 0;
             line-height: 1.5;
         }}
-        .steps {{
-            text-align: left;
-            margin-bottom: 28px;
-        }}
-        .step {{
-            display: flex;
-            gap: 14px;
-            align-items: flex-start;
-            margin-bottom: 18px;
-        }}
-        .step-num {{
-            flex-shrink: 0;
-            width: 28px;
-            height: 28px;
-            background: rgba(39, 197, 139, 0.15);
-            color: #27C58B;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 13px;
-            font-weight: 700;
-        }}
-        .step-content {{
-            flex: 1;
-        }}
-        .step-title {{
-            color: #F9F7F6;
-            font-weight: 600;
-            font-size: 14px;
-            margin-bottom: 3px;
-        }}
-        .step-desc {{
-            color: #9CA3AF;
-            font-size: 13px;
-            line-height: 1.4;
-        }}
-        .app-links {{
-            display: flex;
-            gap: 10px;
-            margin-top: 8px;
-        }}
-        .app-link {{
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            padding: 8px 14px;
-            background: #072218;
-            border: 1px solid #1C4033;
-            border-radius: 8px;
-            color: #F9F7F6;
-            text-decoration: none;
-            font-size: 13px;
-            font-weight: 500;
-            transition: border-color 0.2s;
-        }}
-        .app-link:hover {{
-            border-color: #27C58B;
-        }}
         .divider {{
             border-top: 1px solid #1C4033;
             margin: 0 0 20px 0;
@@ -490,62 +460,56 @@ pub async fn claim_post(
         .web-link:hover {{
             background: #1AA575;
         }}
+        .instruction {{
+            color: #BEB3A7;
+            font-size: 14px;
+            line-height: 1.5;
+            margin: 0 0 24px 0;
+        }}
         .note {{
             color: #9CA3AF;
             font-size: 12px;
-            margin-top: 16px;
+            margin-top: 20px;
             line-height: 1.4;
+        }}
+        .note a {{
+            color: #27C58B;
+            text-decoration: none;
+        }}
+        .note a:hover {{
+            text-decoration: underline;
         }}
     </style>
 </head>
 <body>
     <div class="container">
+        <svg class="logo" viewBox="0 0 240 100" xmlns="http://www.w3.org/2000/svg" aria-label="Synvya">
+            <g fill="#1DB054">
+                <rect x="20" y="60" width="45" height="6" rx="3" />
+                <path d="M25 58 C25 35 60 35 60 58 Z" />
+                <circle cx="42.5" cy="36" r="3" />
+                <path d="M68 48 L78 58 L68 68 V62 H58 V54 H68 V48 Z" />
+            </g>
+            <text x="90" y="62" font-family="Arial, sans-serif" font-size="42" fill="#1DB054" font-weight="400">Synvya</text>
+        </svg>
+
         <div class="checkmark">&#10003;</div>
         <h1>Account Claimed!</h1>
         <p class="subtitle">Welcome, {display_name}. Your credentials have been set.</p>
 
-        <div class="steps">
-            <div class="step">
-                <div class="step-num">1</div>
-                <div class="step-content">
-                    <div class="step-title">Get the App</div>
-                    <div class="step-desc">Download Synvya for the best experience.</div>
-                    <div class="app-links">
-                        <a class="app-link" href="https://apps.apple.com/app/divine-video/id6744577425" target="_blank">
-                            &#63743; App Store
-                        </a>
-                        <a class="app-link" href="https://play.google.com/store/apps/details?id=com.openvine.divine" target="_blank">
-                            &#9654; Google Play
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="step">
-                <div class="step-num">2</div>
-                <div class="step-content">
-                    <div class="step-title">Sign In</div>
-                    <div class="step-desc">Use the email and password you just set to sign in.</div>
-                </div>
-            </div>
-            <div class="step">
-                <div class="step-num">3</div>
-                <div class="step-content">
-                    <div class="step-title">Your Content is Waiting</div>
-                    <div class="step-desc">Your videos and profile are ready to go.</div>
-                </div>
-            </div>
-        </div>
-
         <div class="divider"></div>
 
-        <a class="web-link" href="https://divine.video" target="_blank">
-            Open Synvya on Web
+        <p class="instruction">Use the email and password you just set to sign in to Synvya Admin.</p>
+
+        <a class="web-link" href="{admin_base_url}">
+            Open Synvya Admin
         </a>
-        <p class="note">You can also access your account at divine.video</p>
+        <p class="note">Need help? Contact <a href="mailto:support@synvya.com">support@synvya.com</a></p>
     </div>
 </body>
-</html>"#,
+</html>"##,
         display_name = html_escape(&display_name_str),
+        admin_base_url = html_escape(&admin_base_url),
     );
 
     Ok(([(header::SET_COOKIE, cookie_value)], Html(html)).into_response())

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -26,6 +26,13 @@ fn get_server_keys() -> Result<Keys, ClaimError> {
 #[derive(Debug, Deserialize)]
 pub struct ClaimQuery {
     pub token: String,
+    /// Optional pre-fill for the email input. Set by callers that already
+    /// know the recipient's email (e.g. claim-tokens/batch with
+    /// `delivery_email`). Convenience only: the user can edit the value
+    /// in the form, and `claim_post` does not enforce a match. See
+    /// `docs/synvya/admin-user-provisioning.md` for the design rationale.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 /// Form data for POST /claim
@@ -65,6 +72,7 @@ pub async fn claim_get(
 
     let display_name_str = display_name.unwrap_or_else(|| username.clone().unwrap_or_default());
     let username_str = username.unwrap_or_default();
+    let prefill_email = params.email.as_deref().unwrap_or("");
 
     let html = format!(
         r#"<!DOCTYPE html>
@@ -199,7 +207,7 @@ pub async fn claim_get(
             <input type="hidden" name="token" value="{token}">
 
             <label for="email">Email</label>
-            <input type="email" id="email" name="email" required placeholder="your@email.com">
+            <input type="email" id="email" name="email" required placeholder="your@email.com" value="{email}">
 
             <label for="password">Password</label>
             <input type="password" id="password" name="password" required placeholder="••••••••" minlength="8">
@@ -238,6 +246,7 @@ pub async fn claim_get(
         display_name = html_escape(&display_name_str),
         username = html_escape(&username_str),
         token = html_escape(&params.token),
+        email = html_escape(prefill_email),
     );
 
     Ok(Html(html).into_response())

--- a/docker-compose.synvya.yml
+++ b/docker-compose.synvya.yml
@@ -77,6 +77,10 @@ services:
       # Synvya hosts the password reset page on a different domain
       # (account.synvya.com / account.staging.synvya.com) from the auth host.
       PASSWORD_RESET_BASE_URL: ${PASSWORD_RESET_BASE_URL:?error}
+      # Synvya Admin lives on a separate host. The post-claim success page
+      # in the keycast claim flow links to this URL so newly-onboarded
+      # admins land directly on admin.synvya.com (or staging equivalent).
+      ADMIN_BASE_URL: ${ADMIN_BASE_URL:?error}
       DISABLE_EMAILS:
       # Frontend
       VITE_DOMAIN: ${VITE_DOMAIN:-}

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -19,11 +19,13 @@ if [ "$ENV" = "staging" ]; then
     KMS_KEY_ID=alias/keycast-master-key
     INVITE_BASE_URL=https://account.staging.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.staging.synvya.com
+    ADMIN_BASE_URL=https://admin.staging.synvya.com
 elif [ "$ENV" = "production" ]; then
     DOMAIN=auth.synvya.com
     KMS_KEY_ID=alias/synvya-production-keycast-masterkey
     INVITE_BASE_URL=https://account.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.synvya.com
+    ADMIN_BASE_URL=https://admin.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1
@@ -46,6 +48,7 @@ BASE_URL=https://$DOMAIN
 APP_URL=https://$DOMAIN
 INVITE_BASE_URL=$INVITE_BASE_URL
 PASSWORD_RESET_BASE_URL=$PASSWORD_RESET_BASE_URL
+ADMIN_BASE_URL=$ADMIN_BASE_URL
 VITE_DOMAIN=https://$DOMAIN
 FROM_EMAIL=noreply@synvya.com
 FROM_NAME=Synvya


### PR DESCRIPTION
## Summary

Three commits that improve the claim flow for Synvya admin user provisioning:

1. **Email pre-fill on the claim form.** `GET /api/claim` now accepts an optional `email` query param and pre-fills the email input. `claim-tokens/batch` appends `&email=<urlencoded>` when `delivery_email` is set, so recipients land on a form that already knows their email. Convenience only — `claim_post` doesn't enforce a match.
2. **Rebrand both claim pages for Synvya Admin.** The claim form and the post-claim success page were diVine-flavored leftovers from upstream (App Store / Google Play badges, "Your videos are waiting", divine.video footer). Both pages now show the Synvya wordmark logo, and the success page directs the new admin to Synvya Admin via a new `ADMIN_BASE_URL` env var (default `https://admin.synvya.com`).
3. **Wire `ADMIN_BASE_URL` through the deploy.** `scripts/load-secrets.sh` and `docker-compose.synvya.yml` set/forward the per-environment URL.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p keycast_api` green
- [ ] After deploy: trigger an admin invite from systemtools, click the email link, confirm the claim form pre-fills the recipient's email and shows the Synvya logo, complete the claim, confirm the success page shows "Open Synvya Admin" and the button leads to `admin.staging.synvya.com` (staging) or `admin.synvya.com` (production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)