### PR TITLE
feat(admin): support-users — gate widen + JIT team support-access endpoints

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -7,12 +7,18 @@ use chrono::{Duration, Utc};
 use nostr_sdk::{FromBech32, Keys};
 use serde::{Deserialize, Serialize};
 
+use secrecy::ExposeSecret;
+
 use super::routes::AuthState;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
+use crate::state::{get_key_manager, get_secret_pool};
+use keycast_core::bunker_key::derive_bunker_keys;
 use keycast_core::repositories::{
-    ClaimTokenRepository, OAuthAuthorizationRepository, UserRepository,
+    AuthorizationRepository, ClaimTokenRepository, OAuthAuthorizationRepository, PolicyRepository,
+    StoredKeyRepository, TeamRepository, UserRepository,
 };
+use keycast_core::types::authorization::Authorization;
 use keycast_core::types::claim_token::generate_claim_token;
 
 /// Admin token expiry in days (30 days for long-lived admin tokens)
@@ -23,6 +29,12 @@ const PRELOAD_TOKEN_EXPIRY_DAYS: i64 = 30;
 
 /// Redis key for the support admins set
 const SUPPORT_ADMINS_KEY: &str = "support_admins";
+
+/// Default expiry for support-issued authorizations (§8.2 of support-users.md).
+const DEFAULT_SUPPORT_AUTH_EXPIRY_HOURS: i64 = 24;
+
+/// Server-enforced ceiling on support-issued authorization lifetime.
+const MAX_SUPPORT_AUTH_EXPIRY_HOURS: i64 = 24 * 7;
 
 /// Full admin: has admin_role == "full" in UCAN, or pubkey in ALLOWED_PUBKEYS whitelist.
 /// Full admins can access all admin endpoints including token generation and user preloading.
@@ -1173,6 +1185,294 @@ pub async fn revoke_authorization(
     Ok(Json(RevokeAuthorizationResponse {
         revoked: true,
         authorization_id,
+    }))
+}
+
+// ============================================================================
+// POST /api/admin/teams/:id/support-access — JIT membership on a team
+// ============================================================================
+
+#[derive(Debug, Default, Deserialize)]
+pub struct GrantSupportAccessRequest {
+    /// Optional policy id; defaults to the team's first policy ("All Access").
+    #[serde(default)]
+    pub policy_id: Option<i32>,
+    /// Optional human-readable suffix for audit clarity. The server always
+    /// prefixes with `support:{caller_pubkey_hex}` regardless of input — the
+    /// prefix is the source of truth for the release endpoint's filter.
+    #[serde(default)]
+    pub label: Option<String>,
+    /// Optional authorization lifetime in hours. Defaults to 24, capped at 168.
+    #[serde(default)]
+    pub expires_in_hours: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GrantSupportAccessResponse {
+    pub team_id: i32,
+    pub stored_key_pubkey: String,
+    pub authorization: Authorization,
+    pub bunker_url: String,
+}
+
+/// Add the calling support admin as a `member` of the team (idempotent — admin
+/// rows are preserved), mint a fresh authorization against the team's stored
+/// key, and return the bunker URL. See `docs/synvya/support-users.md` §3.2.
+pub async fn grant_team_support_access(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Path(team_id): Path<i32>,
+    Json(req): Json<GrantSupportAccessRequest>,
+) -> ApiResult<Json<GrantSupportAccessResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Support admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+    let caller = &auth.pubkey;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    team_repo
+        .find(tenant_id, team_id)
+        .await
+        .map_err(|_| ApiError::not_found("Team not found"))?;
+
+    let key_repo = StoredKeyRepository::new(pool.clone());
+    let stored_keys = key_repo
+        .list_by_team(tenant_id, team_id)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to load stored keys: {}", e)))?;
+
+    let stored_key = stored_keys.into_iter().next().ok_or_else(|| {
+        ApiError::bad_request(
+            "team has no stored key — the agent who created it must finish provisioning first",
+        )
+    })?;
+
+    let policy_repo = PolicyRepository::new(pool.clone());
+    let policy_id = match req.policy_id {
+        Some(id) => {
+            if !policy_repo
+                .exists_for_team(team_id, id)
+                .await
+                .map_err(|e| ApiError::internal(format!("Failed to verify policy: {}", e)))?
+            {
+                return Err(ApiError::not_found("Policy not found for this team"));
+            }
+            id
+        }
+        None => {
+            policy_repo
+                .list_by_team(team_id)
+                .await
+                .map_err(|e| ApiError::internal(format!("Failed to load policies: {}", e)))?
+                .into_iter()
+                .next()
+                .ok_or_else(|| ApiError::internal("Team has no policies"))?
+                .id
+        }
+    };
+
+    if !team_repo
+        .is_member(team_id, caller)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to check membership: {}", e)))?
+    {
+        team_repo
+            .add_member(team_id, caller, "member")
+            .await
+            .map_err(|e| ApiError::internal(format!("Failed to add support member: {}", e)))?;
+    }
+
+    let secret_pool = get_secret_pool().map_err(|e| ApiError::internal(e.to_string()))?;
+    let secret_pair = secret_pool
+        .get()
+        .await
+        .ok_or_else(|| ApiError::internal("Secret pool exhausted".to_string()))?;
+    let connection_secret = secret_pair.secret;
+    let secret_hash = secret_pair.hash;
+
+    let key_manager = get_key_manager().map_err(|e| ApiError::internal(e.to_string()))?;
+    let decrypted_stored_key = key_manager
+        .decrypt(&stored_key.secret_key)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to decrypt stored key: {}", e)))?;
+    let stored_key_secret = nostr_sdk::SecretKey::from_slice(&decrypted_stored_key)
+        .map_err(|e| ApiError::internal(format!("Invalid stored key: {}", e)))?;
+    let bunker_keys = derive_bunker_keys(&stored_key_secret, &secret_hash);
+
+    let relays = serde_json::json!(Vec::<String>::new());
+
+    let hours = req
+        .expires_in_hours
+        .unwrap_or(DEFAULT_SUPPORT_AUTH_EXPIRY_HOURS)
+        .clamp(1, MAX_SUPPORT_AUTH_EXPIRY_HOURS);
+    let expires_at = Utc::now() + Duration::hours(hours);
+
+    let label = match req
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(suffix) => format!("support:{} ({})", caller, suffix),
+        None => format!("support:{}", caller),
+    };
+
+    let auth_repo = AuthorizationRepository::new(pool.clone());
+    let authorization = auth_repo
+        .create(
+            tenant_id,
+            stored_key.id,
+            policy_id,
+            &secret_hash,
+            &bunker_keys.public_key().to_hex(),
+            &relays,
+            None,
+            Some(expires_at),
+            Some(&label),
+        )
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to create authorization: {}", e)))?;
+
+    let bunker_url = Authorization::generate_bunker_url(
+        &bunker_keys.public_key().to_hex(),
+        connection_secret.expose_secret(),
+    );
+
+    if let Some(tx) = &auth_state.auth_tx {
+        use keycast_core::authorization_channel::AuthorizationCommand;
+        if let Err(e) = tx
+            .send(AuthorizationCommand::Upsert {
+                bunker_pubkey: bunker_keys.public_key().to_hex(),
+                tenant_id,
+                is_oauth: false,
+            })
+            .await
+        {
+            tracing::warn!(
+                "Failed to notify signer of support-access grant for {}: {}",
+                bunker_keys.public_key().to_hex(),
+                e
+            );
+        }
+    }
+
+    tracing::info!(
+        "Support access granted: team={} support_admin={} authorization={}",
+        team_id,
+        &caller[..8.min(caller.len())],
+        authorization.id,
+    );
+
+    Ok(Json(GrantSupportAccessResponse {
+        team_id,
+        stored_key_pubkey: stored_key.pubkey.clone(),
+        authorization,
+        bunker_url,
+    }))
+}
+
+// ============================================================================
+// DELETE /api/admin/teams/:id/support-access — release JIT membership
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct ReleaseSupportAccessResponse {
+    pub team_id: i32,
+    pub revoked_authorizations: usize,
+    pub removed_membership: bool,
+}
+
+/// Revoke the calling support admin's active authorizations on the team
+/// (identified by the `support:{caller}` label prefix) and remove their
+/// `member` row. Admin rows are preserved. See §3.3.
+pub async fn release_team_support_access(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Path(team_id): Path<i32>,
+) -> ApiResult<Json<ReleaseSupportAccessResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Support admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+    let caller = &auth.pubkey;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    team_repo
+        .find(tenant_id, team_id)
+        .await
+        .map_err(|_| ApiError::not_found("Team not found"))?;
+
+    let auth_repo = AuthorizationRepository::new(pool.clone());
+    let active = auth_repo
+        .find_active_support_for_caller(tenant_id, team_id, caller)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to load support authorizations: {}", e)))?;
+
+    let mut revoked_count = 0usize;
+    for (auth_id, bunker_pubkey) in &active {
+        let bunker_pubkey_revoked = auth_repo
+            .revoke(tenant_id, *auth_id, Some("support_session_end"))
+            .await
+            .map_err(|e| ApiError::internal(format!("Failed to revoke authorization: {}", e)))?;
+
+        if bunker_pubkey_revoked.is_none() {
+            // Already revoked between the lookup and now — skip the daemon notify.
+            continue;
+        }
+        revoked_count += 1;
+
+        if let Some(tx) = &auth_state.auth_tx {
+            use keycast_core::authorization_channel::AuthorizationCommand;
+            if let Err(e) = tx
+                .send(AuthorizationCommand::Remove {
+                    bunker_pubkey: bunker_pubkey.clone(),
+                })
+                .await
+            {
+                tracing::warn!(
+                    "Failed to notify signer of support-access release for {}: {}",
+                    bunker_pubkey,
+                    e
+                );
+            }
+        }
+    }
+
+    let mut removed_membership = false;
+    match team_repo.get_member(team_id, caller).await {
+        Ok(member) if matches!(member.role, keycast_core::types::user::TeamUserRole::Member) => {
+            team_repo
+                .remove_member(team_id, caller)
+                .await
+                .map_err(|e| ApiError::internal(format!("Failed to remove member: {}", e)))?;
+            removed_membership = true;
+        }
+        Ok(_) => {
+            // Caller is admin (e.g., they created this team) — leave the row.
+        }
+        Err(_) => {
+            // No membership row (idempotent re-call) — nothing to remove.
+        }
+    }
+
+    tracing::info!(
+        "Support access released: team={} support_admin={} revoked={}",
+        team_id,
+        &caller[..8.min(caller.len())],
+        revoked_count,
+    );
+
+    Ok(Json(ReleaseSupportAccessResponse {
+        team_id,
+        revoked_authorizations: revoked_count,
+        removed_membership,
     }))
 }
 

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -203,6 +203,10 @@ pub fn api_routes(
             post(admin::revoke_authorization),
         )
         .route(
+            "/admin/teams/:id/support-access",
+            post(admin::grant_team_support_access).delete(admin::release_team_support_access),
+        )
+        .route(
             "/admin/support-admins",
             get(admin::list_support_admins).post(admin::add_support_admin),
         )

--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -65,7 +65,10 @@ pub async fn create_team(
         .await?
         == 0;
 
-    if !super::admin::is_full_admin(&auth) && !can_create_first_team {
+    let is_full = super::admin::is_full_admin(&auth);
+    let is_support = !is_full && super::admin::is_support_admin(&auth).await;
+
+    if !is_full && !is_support && !can_create_first_team {
         tracing::warn!(
             "Team creation denied for non-admin pubkey: {}",
             user_pubkey_hex
@@ -87,6 +90,15 @@ pub async fn create_team(
             allowed_kinds_config,
         )
         .await?;
+
+    if is_support {
+        tracing::info!(
+            "Team created by support admin: team_id={} support_admin={} name={}",
+            team_with_relations.team.id,
+            &user_pubkey_hex[..8.min(user_pubkey_hex.len())],
+            request.name,
+        );
+    }
 
     Ok(Json(team_with_relations))
 }

--- a/api/tests/admin_support_access_test.rs
+++ b/api/tests/admin_support_access_test.rs
@@ -1,0 +1,311 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for the AuthorizationRepository::find_active_support_for_caller
+// ABOUTME: helper that backs DELETE /api/admin/teams/:id/support-access (label-prefix filter,
+// ABOUTME: tenant scoping, team scoping, exclusion of revoked rows).
+
+use keycast_core::custom_permissions::allowed_kinds::AllowedKindsConfig;
+use keycast_core::repositories::{AuthorizationRepository, TeamRepository};
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+
+const TENANT_A: i64 = 1;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+/// Ensure a tenant row exists. The default tenant_id=1 is created by initial
+/// migrations; second tenant is inserted lazily for the cross-tenant test.
+async fn ensure_tenant(pool: &PgPool, tenant_id: i64) {
+    let _ = sqlx::query(
+        "INSERT INTO tenants (id, name, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(tenant_id)
+    .bind(format!("test-tenant-{}", tenant_id))
+    .execute(pool)
+    .await;
+}
+
+/// Ensure a user row exists for a pubkey on a given tenant.
+async fn ensure_user(pool: &PgPool, tenant_id: i64, pubkey: &str) {
+    let _ = sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (pubkey, tenant_id) DO NOTHING",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .execute(pool)
+    .await;
+}
+
+struct Fixture {
+    team_id: i32,
+    stored_key_id: i32,
+    policy_id: i32,
+}
+
+/// Provision a team with a stored key and an "All Access" policy, returning ids.
+/// Each test gets a fresh team with a unique name to avoid cross-test pollution.
+async fn provision_team(pool: &PgPool, tenant_id: i64, admin_pubkey: &str) -> Fixture {
+    ensure_tenant(pool, tenant_id).await;
+    ensure_user(pool, tenant_id, admin_pubkey).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let allowed_kinds_config = serde_json::to_value(AllowedKindsConfig::default()).unwrap();
+    let team_name = format!("Test Team {}", Uuid::new_v4());
+
+    let team_with_relations = team_repo
+        .create_with_admin(tenant_id, &team_name, admin_pubkey, allowed_kinds_config)
+        .await
+        .expect("create_with_admin should succeed");
+
+    let team_id = team_with_relations.team.id;
+    let policy_id = team_with_relations.policies[0].policy.id;
+
+    // Insert a stored key directly. StoredKeyRepository::create requires a
+    // fully-encrypted secret; for label-filter tests a placeholder secret_key
+    // blob is sufficient.
+    let pubkey_hex = Keys::generate().public_key().to_hex();
+    let stored_key_id: i32 = sqlx::query_scalar(
+        "INSERT INTO stored_keys (tenant_id, team_id, name, pubkey, secret_key, created_at, updated_at)
+         VALUES ($1, $2, 'test-key', $3, $4::bytea, NOW(), NOW())
+         RETURNING id",
+    )
+    .bind(tenant_id)
+    .bind(team_id)
+    .bind(&pubkey_hex)
+    .bind(b"placeholder-encrypted-key".as_ref())
+    .fetch_one(pool)
+    .await
+    .expect("stored_key insert should succeed");
+
+    Fixture {
+        team_id,
+        stored_key_id,
+        policy_id,
+    }
+}
+
+async fn insert_authorization(
+    repo: &AuthorizationRepository,
+    tenant_id: i64,
+    fixture: &Fixture,
+    label: Option<&str>,
+) -> i32 {
+    let bunker_pubkey = Keys::generate().public_key().to_hex();
+    let relays = serde_json::json!(Vec::<String>::new());
+    let auth = repo
+        .create(
+            tenant_id,
+            fixture.stored_key_id,
+            fixture.policy_id,
+            "test-secret-hash",
+            &bunker_pubkey,
+            &relays,
+            None,
+            None,
+            label,
+        )
+        .await
+        .expect("auth insert should succeed");
+    auth.id
+}
+
+async fn cleanup_team(pool: &PgPool, tenant_id: i64, team_id: i32) {
+    // Cascade-friendly cleanup in dependency order.
+    let _ = sqlx::query(
+        "DELETE FROM authorizations WHERE stored_key_id IN
+            (SELECT id FROM stored_keys WHERE team_id = $1 AND tenant_id = $2)",
+    )
+    .bind(team_id)
+    .bind(tenant_id)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM stored_keys WHERE team_id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM policy_permissions WHERE policy_id IN (SELECT id FROM policies WHERE team_id = $1)")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM policies WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM team_users WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM teams WHERE id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_returns_only_caller_label() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+    let other_support = Keys::generate().public_key().to_hex();
+
+    let fx = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    // Caller's own support-labeled auth — should match.
+    let mine =
+        insert_authorization(&repo, TENANT_A, &fx, Some(&format!("support:{}", support))).await;
+
+    // A different support admin's auth on the same team — should NOT match.
+    let other = insert_authorization(
+        &repo,
+        TENANT_A,
+        &fx,
+        Some(&format!("support:{}", other_support)),
+    )
+    .await;
+
+    // An owner-minted auth with no support label — should NOT match.
+    let owner_auth = insert_authorization(&repo, TENANT_A, &fx, Some("server-bunker")).await;
+
+    // A null-label auth — should NOT match.
+    let null_label_auth = insert_authorization(&repo, TENANT_A, &fx, None).await;
+
+    let found = repo
+        .find_active_support_for_caller(TENANT_A, fx.team_id, &support)
+        .await
+        .expect("query should succeed");
+
+    let ids: Vec<i32> = found.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&mine), "caller's own auth must be returned");
+    assert!(
+        !ids.contains(&other),
+        "another support admin's auth must NOT be returned"
+    );
+    assert!(
+        !ids.contains(&owner_auth),
+        "owner-minted auth must NOT be returned"
+    );
+    assert!(
+        !ids.contains(&null_label_auth),
+        "null-label auth must NOT be returned"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx.team_id).await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_excludes_revoked() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+
+    let fx = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    let label = format!("support:{}", support);
+    let live = insert_authorization(&repo, TENANT_A, &fx, Some(&label)).await;
+    let to_revoke = insert_authorization(&repo, TENANT_A, &fx, Some(&label)).await;
+
+    repo.revoke(TENANT_A, to_revoke, Some("test"))
+        .await
+        .expect("revoke should succeed");
+
+    let found = repo
+        .find_active_support_for_caller(TENANT_A, fx.team_id, &support)
+        .await
+        .expect("query should succeed");
+
+    let ids: Vec<i32> = found.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&live), "live auth must be returned");
+    assert!(
+        !ids.contains(&to_revoke),
+        "revoked auth must NOT be returned"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx.team_id).await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_is_team_scoped() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+
+    let fx_a = provision_team(&pool, TENANT_A, &admin).await;
+    let fx_b = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    let label = format!("support:{}", support);
+    let on_a = insert_authorization(&repo, TENANT_A, &fx_a, Some(&label)).await;
+    let on_b = insert_authorization(&repo, TENANT_A, &fx_b, Some(&label)).await;
+
+    let found_a = repo
+        .find_active_support_for_caller(TENANT_A, fx_a.team_id, &support)
+        .await
+        .expect("query should succeed");
+    let ids_a: Vec<i32> = found_a.iter().map(|(id, _)| *id).collect();
+    assert!(ids_a.contains(&on_a));
+    assert!(
+        !ids_a.contains(&on_b),
+        "team B auth must not appear for team A query"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx_a.team_id).await;
+    cleanup_team(&pool, TENANT_A, fx_b.team_id).await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_label_suffix_matches() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+
+    let fx = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    // Grant endpoint stamps `support:{caller} (suffix)` when a label suffix is
+    // supplied; the LIKE filter must match the prefix variant.
+    let with_suffix = insert_authorization(
+        &repo,
+        TENANT_A,
+        &fx,
+        Some(&format!("support:{} (manual debug)", support)),
+    )
+    .await;
+
+    let found = repo
+        .find_active_support_for_caller(TENANT_A, fx.team_id, &support)
+        .await
+        .expect("query should succeed");
+
+    let ids: Vec<i32> = found.iter().map(|(id, _)| *id).collect();
+    assert!(
+        ids.contains(&with_suffix),
+        "labels with a suffix must still match the prefix filter"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx.team_id).await;
+}

--- a/core/src/repositories/authorization.rs
+++ b/core/src/repositories/authorization.rs
@@ -105,6 +105,35 @@ impl AuthorizationRepository {
         .map_err(Into::into)
     }
 
+    /// Find a support admin's own active authorizations on a team, identified
+    /// by the `support:{caller_pubkey_hex}` label prefix stamped at grant time.
+    ///
+    /// Returns `(authorization_id, bunker_public_key)` pairs. Used by the
+    /// `DELETE /admin/teams/:id/support-access` endpoint to bulk-revoke.
+    pub async fn find_active_support_for_caller(
+        &self,
+        tenant_id: i64,
+        team_id: i32,
+        caller_pubkey_hex: &str,
+    ) -> Result<Vec<(i32, String)>, RepositoryError> {
+        let label_prefix = format!("support:{}", caller_pubkey_hex);
+        sqlx::query_as::<_, (i32, String)>(
+            "SELECT a.id, a.bunker_public_key
+             FROM authorizations a
+             JOIN stored_keys sk ON sk.id = a.stored_key_id
+             WHERE a.tenant_id = $1
+               AND sk.team_id = $2
+               AND a.revoked_at IS NULL
+               AND a.label LIKE $3 || '%'",
+        )
+        .bind(tenant_id)
+        .bind(team_id)
+        .bind(label_prefix)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
     /// Soft-delete an authorization by setting `revoked_at = NOW()`.
     /// Returns the bunker_public_key of the revoked row (used by the caller to
     /// notify the signer daemon via the authorization channel), or `None` if

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -6,6 +6,7 @@ Spec for letting Synvya support staff create restaurants on behalf of owners and
 - [Cross-system `support-users.md`](https://github.com/Synvya/docs/blob/main/architecture/support-users.md) — system-wide design and the two-layer authority model.
 - [Server `support-users.md`](https://github.com/Synvya/server/blob/staging/docs/specs/support-users.md) — Synvya server's Support-flag mirror to Keycast.
 - [Systemtools `support-users.md`](https://github.com/Synvya/systemtools/blob/staging/docs/specs/support-users.md) — UI: Support toggle on the admin user row, DynamoDB attribute.
+- [Client `support-users.md`](https://github.com/Synvya/client/blob/staging/docs/specs/support-users.md) — Restaurant app: support picker, support-access wiring, session cleanup on switch and logout.
 
 **System context** (Keycast):
 - [Keycast Service Auth](keycast-service-auth.md) — foundation; the Synvya server's mirror call to Keycast rides on this NIP-98 service-auth path.
@@ -127,6 +128,8 @@ The existing `create_with_admin` repository call ([`core/src/repositories/team.r
 
 ### 3.2 New endpoint: `POST /api/admin/teams/:id/support-access`
 
+The `/support-access` endpoints target **fully-provisioned teams** — the existing-restaurant diagnostic flow (§5.2). For the cold-start flow (§5.1), the support user is already the team's admin via `create_with_admin` and uses the standard team-admin endpoints (`add_key`, `add_authorization`, `invite_user`); they never call `POST /support-access` for a team they just created.
+
 **Auth**: `is_support_admin()` only. Tenant-scoped via `TenantExtractor`.
 
 **Path params**: `id` — team id.
@@ -134,17 +137,20 @@ The existing `create_with_admin` repository call ([`core/src/repositories/team.r
 **Request body**:
 ```json
 {
-  "policy_id": 42,           // optional; defaults to the team's "All Access" policy
-  "label": "support: maria"  // optional; recorded on the authorization for audit clarity
+  "policy_id": 42,            // optional; defaults to the team's "All Access" policy
+  "label": "support: maria",  // optional; the server prefixes with `support:{caller_pubkey}` for filtering
+  "expires_in_hours": 24      // optional; default 24, server-enforced ceiling 168 (7d)
 }
 ```
 
 **Behavior** (single transaction):
 1. Look up the team and verify it belongs to the caller's tenant.
-2. If the caller is not yet a `team_users` row for this team, insert one with `role = 'member'`. If the caller is already a member, leave the row alone (do not downgrade an admin).
-3. Pick the team's first non-revoked stored key (this is the restaurant identity; teams have exactly one in the current Synvya model).
-4. Mint a fresh `Authorization` against that stored key, with `connected_client_pubkey = caller`, derived bunker keys, and a fresh connection secret. Use the existing `auth_repo.create()` path so the signer daemon picks it up.
-5. Return the bunker URL plus the authorization summary.
+2. If the team has no non-revoked stored key, return **400** (`team has no stored key — the agent who created it must finish provisioning first`). The endpoint is for established teams.
+3. If the caller is not yet a `team_users` row for this team, insert one with `role = 'member'`. If the caller is already a member, leave the row alone (do not downgrade an admin).
+4. Pick the team's first stored key (the restaurant identity; teams have exactly one in the current Synvya model).
+5. Mint a fresh `Authorization` against that stored key with derived bunker keys, a fresh connection secret, `expires_at` per request (default 24h, capped at 7d), and `label = "support:{caller_pubkey_hex}"` (request-supplied label is appended after the prefix). The label is the source of truth for the `DELETE` endpoint's filtering — `connected_client_pubkey` is set later by the signer when the bunker is first used.
+6. Notify the signer daemon via `AuthorizationCommand::Upsert` so the bunker is live without lazy-load latency.
+7. Return the bunker URL plus the authorization summary.
 
 **Response**:
 ```json
@@ -163,9 +169,11 @@ The existing `create_with_admin` repository call ([`core/src/repositories/team.r
 **Auth**: `is_support_admin()` only. Tenant-scoped.
 
 **Behavior** (single transaction):
-1. Find all non-revoked authorizations on this team where `connected_client_pubkey = caller`. Set `revoked_at = NOW()` and `revoked_reason = 'support_session_end'` on each. Notify the signer daemon (`AuthorizationCommand::Remove`) for each one, mirroring [`admin.rs:1138`](../../api/src/api/http/admin.rs).
+1. Find all non-revoked authorizations on this team where `label LIKE 'support:{caller_pubkey_hex}%'`. Set `revoked_at = NOW()` and `revoked_reason = 'support_session_end'` on each. Notify the signer daemon (`AuthorizationCommand::Remove`) for each one, mirroring [`admin.rs:1138`](../../api/src/api/http/admin.rs).
 2. If the caller's `team_users` row has `role = 'member'` (not `admin`), remove it. If they are an `admin` of this team (e.g., they created it), leave the membership alone.
 3. Return a count of revoked authorizations and a `removed_membership: bool`.
+
+The label-based filter is required because `connected_client_pubkey` is populated only when a NIP-46 client first connects; for a freshly minted authorization that has not yet been used, the column is `NULL`. The grant endpoint stamps `label = "support:{caller_pubkey_hex}"` so this filter unambiguously identifies the calling agent's own authorizations.
 
 **Response**:
 ```json


### PR DESCRIPTION
## Summary

Implements the Keycast-side capabilities described in [`docs/synvya/support-users.md`](docs/synvya/support-users.md): a Synvya support agent (UCAN with `admin_role: \"support\"`) can create new restaurant teams and gain just-in-time membership on existing teams to do diagnostic work.

The four-spec set is now complete: server (mirror), systemtools (toggle UI), keycast (this PR), and client ([Synvya/client#464](https://github.com/Synvya/client/pull/464) for the consumer-side UI spec).

## Commits

1. **`docs(synvya): clarify support-users §3.2`** — adds the new client spec link, restricts `/support-access` to fully-provisioned teams (400 on missing stored key), switches the release-side filter from `connected_client_pubkey` (NULL until first connection) to a `label LIKE 'support:{caller}%'` prefix that the grant endpoint stamps at create time.
2. **`feat(admin): widen create_team gate`** — `POST /api/teams` now accepts `is_support_admin` callers in addition to full admins and first-team users. Emits a structured audit line when a support admin creates a team.
3. **`feat(admin): add support-access endpoints`** — `POST /api/admin/teams/:id/support-access` (mints labeled authorization, idempotent membership add, sends `AuthorizationCommand::Upsert`); `DELETE /api/admin/teams/:id/support-access` (bulk-revokes the caller's own support-labeled auths, removes `member` row, preserves `admin`). Adds `AuthorizationRepository::find_active_support_for_caller`.
4. **`test(admin): find_active_support_for_caller filter semantics`** — repository-level integration tests covering the label-prefix filter, revoked exclusion, team scoping, and label-suffix matching. Handler-level HTTP tests are deferred (require a heavier harness than any current admin test sets up).

## Behavior

- Cold-start \"register new restaurant\" flow (§5.1 of the spec): support agent calls `POST /api/teams` (now permitted), becomes admin via `create_with_admin`, then uses the standard team-admin endpoints (`add_key`, `add_authorization`, `invite_user`). No `/support-access` call needed for teams the agent created.
- Diagnostic \"open existing restaurant\" flow (§5.2): client searches via `user-lookup`/`user-teams`, calls `POST /support-access`, receives a `bunker_url` with default-24h / max-7d expiry, JIT membership is added. `DELETE /support-access` cleans up.
- Audit lines: `Team created by support admin: ...`, `Support access granted: ...`, `Support access released: ...`, plus the per-revoke line that already exists.

## Dependencies

The NIP-98 service-auth foundation ([`api/src/api/nip98_extractor.rs`](api/src/api/nip98_extractor.rs)) is already in place, so the `support_admins` Redis mirror call from `Synvya/server` can land independently in that repo.

## Test plan

- [ ] CI runs `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, and `cargo test --features integration-tests` (the new repo tests need a Postgres test DB).
- [ ] Local: `cd api && cargo test --features integration-tests --test admin_support_access_test`.
- [ ] Manual on staging:
  - [ ] Promote a test pubkey to `support_admins` via the existing `POST /api/admin/support-admins` (full-admin auth).
  - [ ] Log in as that user, confirm UCAN carries `admin_role: \"support\"` via `GET /api/admin/status`.
  - [ ] `POST /api/teams` succeeds; team is created with the support agent as `admin`.
  - [ ] On a second pre-existing team (with stored key), `POST /api/admin/teams/:id/support-access` returns a working `bunker_url`; the agent appears as a `member`; signer logs an `Upsert`.
  - [ ] `DELETE /api/admin/teams/:id/support-access` revokes the auth (signer logs `Remove`), removes the `member` row, second call is a no-op.
  - [ ] Audit lines visible in Cloud Logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)