### PR TITLE
feat(teams): server-enrich is_support_member on team responses

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -28,7 +28,7 @@ const ADMIN_TOKEN_EXPIRY_DAYS: i64 = 30;
 const PRELOAD_TOKEN_EXPIRY_DAYS: i64 = 30;
 
 /// Redis key for the support admins set
-const SUPPORT_ADMINS_KEY: &str = "support_admins";
+pub const SUPPORT_ADMINS_KEY: &str = "support_admins";
 
 /// Default expiry for support-issued authorizations (§8.2 of support-users.md).
 const DEFAULT_SUPPORT_AUTH_EXPIRY_HOURS: i64 = 24;

--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -24,6 +24,34 @@ use keycast_core::types::stored_key::PublicStoredKey;
 use keycast_core::types::team::{KeyWithRelations, Team, TeamWithRelations};
 use keycast_core::types::user::{TeamUser, TeamUserRole};
 
+/// Fetch the Redis `support_admins` set as a `HashSet`. Returns `None` when
+/// state or Redis is unavailable; callers should treat that as "no enrichment
+/// possible" and fall back to default `is_support_member: false` on responses.
+async fn fetch_support_admin_set() -> Option<std::collections::HashSet<String>> {
+    let state = crate::state::get_keycast_state().ok()?;
+    let redis = state.redis.as_ref()?;
+    match redis.smembers(super::admin::SUPPORT_ADMINS_KEY).await {
+        Ok(v) => Some(v.into_iter().collect()),
+        Err(e) => {
+            tracing::warn!("Redis SMEMBERS support_admins failed: {}", e);
+            None
+        }
+    }
+}
+
+/// Stamp `is_support_member: true` on each `TeamUser` whose pubkey appears in
+/// the supplied `support_admins` set. Pure function — exposed for unit tests.
+pub(crate) fn mark_support_members(
+    team_users: &mut [TeamUser],
+    support_set: &std::collections::HashSet<String>,
+) {
+    for tu in team_users.iter_mut() {
+        if support_set.contains(&tu.user_pubkey) {
+            tu.is_support_member = true;
+        }
+    }
+}
+
 pub async fn list_teams(
     tenant: crate::api::tenant::TenantExtractor,
     State(pool): State<PgPool>,
@@ -43,7 +71,15 @@ pub async fn list_teams(
         .await
         .map_err(|_| ApiError::not_found("User not found"))?;
 
-    let teams_with_relations = user.teams(&pool, tenant_id).await?;
+    let mut teams_with_relations = user.teams(&pool, tenant_id).await?;
+
+    if !teams_with_relations.is_empty() {
+        if let Some(set) = fetch_support_admin_set().await {
+            for twr in teams_with_relations.iter_mut() {
+                mark_support_members(&mut twr.team_users, &set);
+            }
+        }
+    }
 
     Ok(Json(teams_with_relations))
 }
@@ -116,10 +152,14 @@ pub async fn get_team(
     verify_admin(&pool, &user_pubkey_hex, team_id, tenant_id).await?;
 
     let team_repo = TeamRepository::new(pool.clone());
-    let team_with_relations = team_repo
+    let mut team_with_relations = team_repo
         .find_with_relations(tenant_id, team_id)
         .await
         .map_err(|_| ApiError::not_found("Team not found"))?;
+
+    if let Some(set) = fetch_support_admin_set().await {
+        mark_support_members(&mut team_with_relations.team_users, &set);
+    }
 
     Ok(Json(team_with_relations))
 }
@@ -201,9 +241,13 @@ pub async fn add_user(
         .await?;
 
     // Add the team membership
-    let team_user = team_repo
+    let mut team_user = team_repo
         .add_member(team_id, &new_user_pubkey.to_hex(), request.role.as_str())
         .await?;
+
+    if let Some(set) = fetch_support_admin_set().await {
+        mark_support_members(std::slice::from_mut(&mut team_user), &set);
+    }
 
     Ok(Json(team_user))
 }
@@ -970,5 +1014,82 @@ async fn resolve_display_name(pool: &PgPool, pubkey: &str, tenant_id: i64) -> St
         Some((Some(display_name), _)) if !display_name.is_empty() => display_name,
         Some((_, Some(username))) if !username.is_empty() => username,
         _ => format!("{}…", &pubkey[..8]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::HashSet;
+
+    fn fake_team_user(pubkey: &str, role: TeamUserRole) -> TeamUser {
+        let now = Utc::now();
+        TeamUser {
+            user_pubkey: pubkey.to_string(),
+            team_id: 1,
+            role,
+            email: None,
+            created_at: now,
+            updated_at: now,
+            is_support_member: false,
+        }
+    }
+
+    #[test]
+    fn mark_support_members_flags_only_pubkeys_in_set() {
+        let support = "aaaa".to_string();
+        let owner = "bbbb".to_string();
+        let mut rows = vec![
+            fake_team_user(&support, TeamUserRole::Member),
+            fake_team_user(&owner, TeamUserRole::Admin),
+        ];
+        let set: HashSet<String> = [support.clone()].into_iter().collect();
+
+        mark_support_members(&mut rows, &set);
+
+        assert!(rows[0].is_support_member, "support pubkey must be flagged");
+        assert!(
+            !rows[1].is_support_member,
+            "owner pubkey must NOT be flagged"
+        );
+    }
+
+    #[test]
+    fn mark_support_members_is_idempotent() {
+        let pk = "cccc".to_string();
+        let mut rows = vec![fake_team_user(&pk, TeamUserRole::Member)];
+        let set: HashSet<String> = [pk.clone()].into_iter().collect();
+
+        mark_support_members(&mut rows, &set);
+        mark_support_members(&mut rows, &set);
+
+        assert!(rows[0].is_support_member);
+    }
+
+    #[test]
+    fn mark_support_members_empty_set_is_noop() {
+        let mut rows = vec![fake_team_user("dddd", TeamUserRole::Admin)];
+        let set: HashSet<String> = HashSet::new();
+
+        mark_support_members(&mut rows, &set);
+
+        assert!(!rows[0].is_support_member);
+    }
+
+    #[test]
+    fn mark_support_members_does_not_clear_preexisting_flag() {
+        // If a row was already marked (e.g. enriched upstream), a subsequent
+        // pass with a smaller set must not unset it.
+        let mut rows = vec![fake_team_user("eeee", TeamUserRole::Member)];
+        rows[0].is_support_member = true;
+        let set: HashSet<String> = HashSet::new();
+
+        mark_support_members(&mut rows, &set);
+
+        assert!(
+            rows[0].is_support_member,
+            "preexisting true flag must be preserved"
+        );
     }
 }

--- a/core/src/types/user.rs
+++ b/core/src/types/user.rs
@@ -53,6 +53,13 @@ pub struct TeamUser {
     pub created_at: DateTime<chrono::Utc>,
     /// The date and time the user was last updated
     pub updated_at: DateTime<chrono::Utc>,
+    /// True if `user_pubkey` is currently in the Redis `support_admins` set.
+    /// Populated by API handlers after fetching from the repository; default
+    /// `false` when no enrichment has been done (e.g., daemon code paths,
+    /// Redis unavailable). Not stored in the database.
+    #[serde(default)]
+    #[sqlx(default)]
+    pub is_support_member: bool,
 }
 
 /// The role of a user in a team

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -198,6 +198,27 @@ Both new routes are registered alongside the existing admin block at [`api/src/a
 )
 ```
 
+### 3.5 `is_support_member` enrichment on team responses
+
+Existing team responses gain a per-`TeamUser` boolean so the Restaurant app can label support agents distinctly without holding any admin role. No new routes; the change is additive on the existing payload shape.
+
+Endpoints affected:
+
+| Endpoint | Returns |
+|---|---|
+| `GET /api/teams` | `Vec<TeamWithRelations>` — each `team_users` row carries `is_support_member`. |
+| `GET /api/teams/:id` | `TeamWithRelations` — same enrichment. |
+| `POST /api/teams/:id/users` | `TeamUser` — single row, enriched. |
+
+Behavior:
+
+- For each request, the handler does **one** Redis `SMEMBERS support_admins` call, builds a `HashSet`, and flags any `team_users.user_pubkey` that appears in the set as `is_support_member = true`.
+- When Redis is unavailable (state error, connection failure, missing client), the handler logs a warning and returns `is_support_member: false` for all rows. Capability downgrade, never a hard failure — the response stays valid.
+- The flag is **not stored in the database**. It reflects current support-admin status at request time. A user toggled out of `support_admins` will stop being flagged on the next request after the toggle propagates.
+- Existing clients that ignore unknown fields are unaffected. Clients that read `is_support_member` get the enrichment without any other API change.
+
+The unit-tested helper `mark_support_members(rows: &mut [TeamUser], set: &HashSet<String>)` is the pure core; the handler-side `fetch_support_admin_set()` performs the I/O.
+
 ---
 
 ## 4. Reused Surface (no changes)
@@ -332,7 +353,7 @@ No structured audit table is added in this spec; the structured log lines feed C
 
 2. **JIT membership leak**. If `release_team_support_access` is never called (browser crashes, network failure, the support admin closes their laptop without logging out), the support admin remains a member with a live authorization until either (a) the authorization expires or (b) another support admin manually revokes via `revoke_authorization`. To bound this, support-issued authorizations are minted with a short `expires_at` (default 24h, configurable per call). The signer daemon enforces expiry.
 
-3. **Restaurant owner visibility**. After this lands, a restaurant owner viewing their team membership list will see support admins listed alongside the owner during active support sessions. This is a feature, not a leak, but the Restaurant app should label support members distinctly so owners are not confused about who has access. The label is applied client-side based on `team_users.role = 'member'` plus a presence check against the `support_admins` set (read via `GET /api/admin/support-admins` if owner has visibility, or returned inline by `user-teams` for support; this is a client UX decision and out of scope for Keycast).
+3. **Restaurant owner visibility**. After this lands, a restaurant owner viewing their team membership list will see support admins listed alongside the owner during active support sessions. This is a feature, not a leak, but the Restaurant app should label support members distinctly so owners are not confused about who has access. Keycast surfaces the data the client needs by stamping `is_support_member: bool` on each `TeamUser` row in responses from `GET /teams`, `GET /teams/:id`, and `POST /teams/:id/users`; the flag is populated by cross-referencing each member's pubkey against the Redis `support_admins` set on the request path. The visual treatment of the flag (badge, parenthetical) is a client UX decision; the data path is owned by Keycast.
 
 4. **Audit trail tampering**. Support admins cannot delete or amend their own log lines; logs go to Cloud Logging via the standard request path.
 
@@ -348,19 +369,17 @@ No structured audit table is added in this spec; the structured log lines feed C
 
 Keycast (`synvya-staging` branch):
 
-- [ ] Widen `create_team` gate at [`api/src/api/http/teams.rs:68`](../../api/src/api/http/teams.rs) to call `is_support_admin().await`.
-- [ ] Add `grant_team_support_access` handler in [`api/src/api/http/admin.rs`](../../api/src/api/http/admin.rs).
-- [ ] Add `release_team_support_access` handler in the same file.
-- [ ] Register both routes under `/admin/teams/:id/support-access` in [`api/src/api/http/routes.rs`](../../api/src/api/http/routes.rs).
-- [ ] Add structured log lines per §7.
-- [ ] Default authorization expiry of 24h on support-issued authorizations (per §8.2). Make configurable via request body.
+- [x] Widen `create_team` gate at [`api/src/api/http/teams.rs:68`](../../api/src/api/http/teams.rs) to call `is_support_admin().await`.
+- [x] Add `grant_team_support_access` handler in [`api/src/api/http/admin.rs`](../../api/src/api/http/admin.rs).
+- [x] Add `release_team_support_access` handler in the same file.
+- [x] Register both routes under `/admin/teams/:id/support-access` in [`api/src/api/http/routes.rs`](../../api/src/api/http/routes.rs).
+- [x] Add structured log lines per §7.
+- [x] Default authorization expiry of 24h on support-issued authorizations (per §8.2). Make configurable via request body.
+- [x] Add `is_support_member` enrichment on team responses per §3.5 — populated via Redis `SMEMBERS support_admins` on the request path; no database change.
 - [ ] Tests:
-  - [ ] support admin can create a team; non-admin non-support user with one existing team membership cannot.
-  - [ ] support admin can grant + release access on a team they are not a member of; second release is a no-op.
-  - [ ] release does not remove `admin` membership (e.g., the support user who originally created the team).
-  - [ ] release notifies the signer daemon (`AuthorizationCommand::Remove`).
-  - [ ] full admin retains all current capabilities.
-  - [ ] non-support, non-admin caller is forbidden on both new endpoints.
+  - [x] `find_active_support_for_caller` filter: label-prefix matching, revoked exclusion, team scoping, suffix tolerance.
+  - [x] `mark_support_members` helper: only set members flagged, idempotent, empty-set no-op, preexisting flag preserved.
+  - [ ] HTTP-handler tests for grant + release behavior — deferred until an admin-endpoint test harness is established.
 
 Restaurant app (`Synvya/client`, separate PR):
 


### PR DESCRIPTION
## Summary

Closes the gap in the support-users feature where the client could not reliably distinguish support agents from permanent team members in the UI.

The original Keycast spec ([§8.3](docs/synvya/support-users.md#8-security-considerations)) had punted this label as "applied client-side via `GET /api/admin/support-admins`." That endpoint is full-admin gated, which leaves the actual viewers (restaurant owners and the support agents themselves) without a working data path. This PR makes Keycast the source of truth: every `TeamUser` returned to clients now carries an `is_support_member: bool` flag computed at request time from the Redis `support_admins` set.

## Behavior

Endpoints affected (additive — no breaking changes):

| Endpoint | Returns |
|---|---|
| `GET /api/teams` | `Vec<TeamWithRelations>` — each `team_users` row carries `is_support_member`. |
| `GET /api/teams/:id` | `TeamWithRelations` — same enrichment. |
| `POST /api/teams/:id/users` | `TeamUser` — single row, enriched. |

- **One Redis `SMEMBERS support_admins` per request.** Result is hashed once, then cross-referenced O(1) per row.
- **No database change.** The flag is a runtime computation, not stored. A user toggled off the support set stops being flagged on the next request.
- **Safe downgrade.** When Redis is unavailable (state error, missing client, command failure), the handler logs a warning and returns `is_support_member: false` for all rows. Capability downgrade, never a hard failure.
- **Backwards compatible.** Existing clients that ignore unknown fields are unaffected. New clients reading the field get the enrichment without any other API change.

## Commits

1. **`feat(teams): server-enrich is_support_member on team responses`** — `TeamUser` gains the field with `#[sqlx(default)]` + `#[serde(default)]` so DB FromRow and JSON deserialization stay backwards-compatible. Adds `fetch_support_admin_set` and the pure helper `mark_support_members`. Wired into `list_teams`, `get_team`, and `add_user`. Unit tests cover: only-set-members flagged, idempotent, empty-set no-op, preexisting flag preserved (4 passing tests).
2. **`docs(synvya): document is_support_member enrichment`** — adds §3.5 to the support-users spec describing the enrichment behavior, updates §8.3 to replace the original client-side punt with the new server-owned path, and marks the §9 checklist accordingly.

## Companion PR

Client-side spec resolution: [Synvya/client (forthcoming)](https://github.com/Synvya/client/pulls?q=is%3Apr+head%3Afeat/support-users-spec-q4-resolved) closes the corresponding open question (Q4) in the client `support-users.md` spec.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p keycast_api --lib mark_support_members` (4/4 pass)
- [ ] Manual on staging:
  - [ ] Promote a test pubkey via `POST /api/admin/support-admins`.
  - [ ] As a regular user (owner), call `GET /api/teams`. Confirm members in the support set return `is_support_member: true`; others return `false`.
  - [ ] Demote the test pubkey, refetch, confirm flag drops to `false` on next request.
  - [ ] Stop Redis (or simulate) and verify all rows return `is_support_member: false` plus a warning in logs (not a 5xx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)