### PR TITLE
feat(admin): GET /api/admin/team-lookup — restaurant-name search for support agents

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -16,7 +16,7 @@ use crate::state::{get_key_manager, get_secret_pool};
 use keycast_core::bunker_key::derive_bunker_keys;
 use keycast_core::repositories::{
     AuthorizationRepository, ClaimTokenRepository, OAuthAuthorizationRepository, PolicyRepository,
-    StoredKeyRepository, TeamRepository, UserRepository,
+    StoredKeyRepository, TeamRepository, TeamSearchResult, UserRepository,
 };
 use keycast_core::types::authorization::Authorization;
 use keycast_core::types::claim_token::generate_claim_token;
@@ -930,6 +930,94 @@ pub async fn get_user_lookup(
     }
 
     Ok(Json(UserLookupResponse { results, total }))
+}
+
+// ============================================================================
+// GET /api/admin/team-lookup?q=<name> - Search teams by name
+// ============================================================================
+
+/// Maximum number of teams returned by `team-lookup`. Tight enough to render
+/// inline in a picker without scroll; loose enough to disambiguate when many
+/// restaurants share a common word (e.g. "pizza").
+const TEAM_LOOKUP_LIMIT: i64 = 25;
+
+/// Minimum query length before the server runs the search. Shorter queries
+/// would match too many teams to be useful in a picker.
+const TEAM_LOOKUP_MIN_QUERY_LEN: usize = 2;
+
+#[derive(Debug, Deserialize)]
+pub struct TeamLookupQuery {
+    /// Case-insensitive substring of the team name. Required.
+    pub q: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TeamLookupResponse {
+    pub results: Vec<TeamLookupCandidate>,
+    pub total: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TeamLookupCandidate {
+    pub id: i32,
+    pub name: String,
+    /// Emails of admins on the team (deduped). May be empty if no admin has
+    /// an email on file. Useful for disambiguating same-named restaurants.
+    pub admin_emails: Vec<String>,
+    /// `true` if the team has at least one stored key. A team with no stored
+    /// key is not eligible for `POST /admin/teams/:id/support-access`; the
+    /// client should surface this so support agents see why.
+    pub has_stored_key: bool,
+    pub created_at: String,
+}
+
+impl From<TeamSearchResult> for TeamLookupCandidate {
+    fn from(row: TeamSearchResult) -> Self {
+        Self {
+            id: row.id,
+            name: row.name,
+            admin_emails: row.admin_emails,
+            has_stored_key: row.has_stored_key,
+            created_at: row.created_at.to_rfc3339(),
+        }
+    }
+}
+
+/// Look up teams by case-insensitive name substring. Available to support
+/// admins and above. Tenant-scoped. Returns up to 25 candidates with admin
+/// emails and provisioning status to drive the Restaurant app's
+/// "Open another restaurant" search picker.
+pub async fn get_team_lookup(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    axum::extract::Query(query): axum::extract::Query<TeamLookupQuery>,
+) -> ApiResult<Json<TeamLookupResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Support admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+
+    let q = query.q.trim();
+    if q.len() < TEAM_LOOKUP_MIN_QUERY_LEN {
+        return Err(ApiError::bad_request(format!(
+            "Query 'q' must be at least {} characters",
+            TEAM_LOOKUP_MIN_QUERY_LEN
+        )));
+    }
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let rows = team_repo
+        .search_by_name(tenant_id, q, TEAM_LOOKUP_LIMIT)
+        .await
+        .map_err(|e| ApiError::internal(format!("Team search failed: {}", e)))?;
+
+    let results: Vec<TeamLookupCandidate> = rows.into_iter().map(Into::into).collect();
+    let total = results.len();
+
+    Ok(Json(TeamLookupResponse { results, total }))
 }
 
 // ============================================================================

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -198,6 +198,7 @@ pub fn api_routes(
         )
         .route("/admin/user-lookup", get(admin::get_user_lookup))
         .route("/admin/user-teams", get(admin::get_user_teams))
+        .route("/admin/team-lookup", get(admin::get_team_lookup))
         .route(
             "/admin/authorizations/:id/revoke",
             post(admin::revoke_authorization),

--- a/api/tests/admin_team_lookup_test.rs
+++ b/api/tests/admin_team_lookup_test.rs
@@ -1,0 +1,315 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for TeamRepository::search_by_name, the helper
+// ABOUTME: behind GET /api/admin/team-lookup. Covers case-insensitive substring
+// ABOUTME: matching, tenant scoping, admin email aggregation, has_stored_key
+// ABOUTME: flag, and the result limit.
+
+use keycast_core::custom_permissions::allowed_kinds::AllowedKindsConfig;
+use keycast_core::repositories::TeamRepository;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+
+const TENANT_A: i64 = 1;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+async fn ensure_tenant(pool: &PgPool, tenant_id: i64) {
+    let _ = sqlx::query(
+        "INSERT INTO tenants (id, name, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(tenant_id)
+    .bind(format!("test-tenant-{}", tenant_id))
+    .execute(pool)
+    .await;
+}
+
+/// Create a user with optional email. Idempotent on (pubkey, tenant_id).
+async fn ensure_user_with_email(pool: &PgPool, tenant_id: i64, pubkey: &str, email: Option<&str>) {
+    let _ = sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())
+         ON CONFLICT (pubkey, tenant_id) DO UPDATE SET email = EXCLUDED.email",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .bind(email)
+    .execute(pool)
+    .await;
+}
+
+/// Create a team with the given admin and (optionally) a stored key. Returns team_id.
+async fn create_team(
+    pool: &PgPool,
+    tenant_id: i64,
+    name: &str,
+    admin_pubkey: &str,
+    with_stored_key: bool,
+) -> i32 {
+    ensure_tenant(pool, tenant_id).await;
+    ensure_user_with_email(pool, tenant_id, admin_pubkey, None).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let allowed_kinds_config = serde_json::to_value(AllowedKindsConfig::default()).unwrap();
+    let twr = team_repo
+        .create_with_admin(tenant_id, name, admin_pubkey, allowed_kinds_config)
+        .await
+        .expect("create_with_admin should succeed");
+
+    if with_stored_key {
+        let pubkey_hex = Keys::generate().public_key().to_hex();
+        sqlx::query(
+            "INSERT INTO stored_keys (tenant_id, team_id, name, pubkey, secret_key, created_at, updated_at)
+             VALUES ($1, $2, 'test-key', $3, $4::bytea, NOW(), NOW())",
+        )
+        .bind(tenant_id)
+        .bind(twr.team.id)
+        .bind(&pubkey_hex)
+        .bind(b"placeholder-encrypted-key".as_ref())
+        .execute(pool)
+        .await
+        .expect("stored_key insert should succeed");
+    }
+
+    twr.team.id
+}
+
+async fn cleanup_team(pool: &PgPool, tenant_id: i64, team_id: i32) {
+    let _ = sqlx::query("DELETE FROM stored_keys WHERE team_id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "DELETE FROM policy_permissions WHERE policy_id IN (SELECT id FROM policies WHERE team_id = $1)",
+    )
+    .bind(team_id)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM policies WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM team_users WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM teams WHERE id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_search_matches_substring_case_insensitive() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let target_name = format!("Joes Diner {}", unique);
+    let unrelated_name = format!("Bella Bistro {}", unique);
+
+    let target = create_team(&pool, TENANT_A, &target_name, &admin, true).await;
+    let unrelated = create_team(&pool, TENANT_A, &unrelated_name, &admin, true).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let results = team_repo
+        .search_by_name(TENANT_A, &format!("joes {}", &unique[..8]), 25)
+        .await
+        .expect("search should succeed");
+
+    let ids: Vec<i32> = results.iter().map(|r| r.id).collect();
+    assert!(ids.contains(&target), "target team must be in results");
+    assert!(
+        !ids.contains(&unrelated),
+        "unrelated team must NOT be in results"
+    );
+
+    cleanup_team(&pool, TENANT_A, target).await;
+    cleanup_team(&pool, TENANT_A, unrelated).await;
+}
+
+#[tokio::test]
+async fn test_search_aggregates_admin_emails() {
+    let pool = setup_pool().await;
+    let admin1 = Keys::generate().public_key().to_hex();
+    let admin2 = Keys::generate().public_key().to_hex();
+    let member = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let team_name = format!("Multi Admin {}", unique);
+
+    ensure_tenant(&pool, TENANT_A).await;
+    ensure_user_with_email(&pool, TENANT_A, &admin1, Some("admin1@example.com")).await;
+    ensure_user_with_email(&pool, TENANT_A, &admin2, Some("admin2@example.com")).await;
+    ensure_user_with_email(&pool, TENANT_A, &member, Some("member@example.com")).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let allowed_kinds_config = serde_json::to_value(AllowedKindsConfig::default()).unwrap();
+    let twr = team_repo
+        .create_with_admin(TENANT_A, &team_name, &admin1, allowed_kinds_config)
+        .await
+        .expect("create");
+    let team_id = twr.team.id;
+
+    team_repo
+        .add_member(team_id, &admin2, "admin")
+        .await
+        .expect("add second admin");
+    team_repo
+        .add_member(team_id, &member, "member")
+        .await
+        .expect("add member");
+
+    let results = team_repo
+        .search_by_name(TENANT_A, &unique, 25)
+        .await
+        .expect("search");
+    let row = results.iter().find(|r| r.id == team_id).expect("hit");
+
+    let mut emails = row.admin_emails.clone();
+    emails.sort();
+    assert_eq!(
+        emails,
+        vec![
+            "admin1@example.com".to_string(),
+            "admin2@example.com".to_string()
+        ],
+        "admin emails must include both admins, deduped, and exclude the member"
+    );
+
+    cleanup_team(&pool, TENANT_A, team_id).await;
+}
+
+#[tokio::test]
+async fn test_search_has_stored_key_flag() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+
+    let with_key = create_team(
+        &pool,
+        TENANT_A,
+        &format!("WithKey {}", unique),
+        &admin,
+        true,
+    )
+    .await;
+    let without_key =
+        create_team(&pool, TENANT_A, &format!("NoKey {}", unique), &admin, false).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let results = team_repo
+        .search_by_name(TENANT_A, &unique, 25)
+        .await
+        .expect("search");
+
+    let with = results.iter().find(|r| r.id == with_key).expect("with");
+    let without = results
+        .iter()
+        .find(|r| r.id == without_key)
+        .expect("without");
+
+    assert!(with.has_stored_key, "team with stored key must flag true");
+    assert!(
+        !without.has_stored_key,
+        "team without stored key must flag false"
+    );
+
+    cleanup_team(&pool, TENANT_A, with_key).await;
+    cleanup_team(&pool, TENANT_A, without_key).await;
+}
+
+#[tokio::test]
+async fn test_search_is_tenant_scoped() {
+    let pool = setup_pool().await;
+    const TENANT_B: i64 = 999_001;
+    let admin_a = Keys::generate().public_key().to_hex();
+    let admin_b = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let shared_name = format!("Cross Tenant {}", unique);
+
+    let team_a = create_team(&pool, TENANT_A, &shared_name, &admin_a, true).await;
+    let team_b = create_team(&pool, TENANT_B, &shared_name, &admin_b, true).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+
+    let results_a = team_repo
+        .search_by_name(TENANT_A, &unique, 25)
+        .await
+        .expect("search A");
+    let ids_a: Vec<i32> = results_a.iter().map(|r| r.id).collect();
+    assert!(ids_a.contains(&team_a));
+    assert!(
+        !ids_a.contains(&team_b),
+        "tenant B's team must not leak to tenant A"
+    );
+
+    let results_b = team_repo
+        .search_by_name(TENANT_B, &unique, 25)
+        .await
+        .expect("search B");
+    let ids_b: Vec<i32> = results_b.iter().map(|r| r.id).collect();
+    assert!(ids_b.contains(&team_b));
+    assert!(
+        !ids_b.contains(&team_a),
+        "tenant A's team must not leak to tenant B"
+    );
+
+    cleanup_team(&pool, TENANT_A, team_a).await;
+    cleanup_team(&pool, TENANT_B, team_b).await;
+    let _ = sqlx::query("DELETE FROM tenants WHERE id = $1")
+        .bind(TENANT_B)
+        .execute(&pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_search_respects_limit() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let mut team_ids = Vec::new();
+
+    for i in 0..5 {
+        let id = create_team(
+            &pool,
+            TENANT_A,
+            &format!("LimitTest {} {}", unique, i),
+            &admin,
+            false,
+        )
+        .await;
+        team_ids.push(id);
+    }
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let results = team_repo
+        .search_by_name(TENANT_A, &unique, 3)
+        .await
+        .expect("search");
+
+    assert_eq!(results.len(), 3, "limit must be respected");
+
+    for id in team_ids {
+        cleanup_team(&pool, TENANT_A, id).await;
+    }
+}

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -32,6 +32,6 @@ pub use policy::PolicyRepository;
 pub use refresh_token::RefreshTokenRepository;
 pub use registered_client::RegisteredClientRepository;
 pub use stored_key::StoredKeyRepository;
-pub use team::TeamRepository;
+pub use team::{TeamRepository, TeamSearchResult};
 pub use team_invitation::TeamInvitationRepository;
 pub use user::{AdminUserDetails, DeleteAccountResult, UserRepository, VerificationTokenData};

--- a/core/src/repositories/team.rs
+++ b/core/src/repositories/team.rs
@@ -6,7 +6,24 @@ use crate::types::policy::{Policy, PolicyWithPermissions};
 use crate::types::stored_key::{PublicStoredKey, StoredKey};
 use crate::types::team::{Team, TeamWithRelations};
 use crate::types::user::TeamUser;
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 use sqlx::PgPool;
+
+/// Result row for the team-name search used by `GET /api/admin/team-lookup`.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct TeamSearchResult {
+    pub id: i32,
+    pub name: String,
+    pub created_at: DateTime<chrono::Utc>,
+    /// Emails of admins on the team (deduped). Empty when no admin has an
+    /// email on file. Used to disambiguate when multiple teams share a name.
+    pub admin_emails: Vec<String>,
+    /// `true` when the team has at least one row in `stored_keys`. A team
+    /// without a stored key is not eligible for `/support-access`.
+    pub has_stored_key: bool,
+}
 
 /// Repository for team-related database operations.
 #[derive(Debug, Clone)]
@@ -28,6 +45,51 @@ impl TeamRepository {
         .bind(tenant_id)
         .bind(team_id)
         .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Search teams by name within a tenant. Returns up to `limit` rows whose
+    /// names match the case-insensitive substring `query`. Each row carries
+    /// the team's admin emails (for disambiguation when multiple teams share
+    /// a name) and a flag indicating whether the team has a stored key
+    /// (a team with no stored key is not eligible for `/support-access`).
+    ///
+    /// Used by `GET /api/admin/team-lookup`.
+    pub async fn search_by_name(
+        &self,
+        tenant_id: i64,
+        query: &str,
+        limit: i64,
+    ) -> Result<Vec<TeamSearchResult>, RepositoryError> {
+        let pattern = format!("%{}%", query);
+        sqlx::query_as::<_, TeamSearchResult>(
+            "SELECT
+                t.id,
+                t.name,
+                t.created_at,
+                COALESCE(
+                    ARRAY_AGG(DISTINCT u.email)
+                        FILTER (WHERE u.email IS NOT NULL AND tu.role = 'admin'),
+                    '{}'
+                )::text[] AS admin_emails,
+                EXISTS (
+                    SELECT 1 FROM stored_keys sk
+                    WHERE sk.team_id = t.id AND sk.tenant_id = $1
+                ) AS has_stored_key
+             FROM teams t
+             LEFT JOIN team_users tu ON tu.team_id = t.id
+             LEFT JOIN users u ON u.pubkey = tu.user_pubkey AND u.tenant_id = $1
+             WHERE t.tenant_id = $1
+               AND t.name ILIKE $2
+             GROUP BY t.id, t.name, t.created_at
+             ORDER BY t.name
+             LIMIT $3",
+        )
+        .bind(tenant_id)
+        .bind(pattern)
+        .bind(limit)
+        .fetch_all(&self.pool)
         .await
         .map_err(Into::into)
     }

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -219,6 +219,44 @@ Behavior:
 
 The unit-tested helper `mark_support_members(rows: &mut [TeamUser], set: &HashSet<String>)` is the pure core; the handler-side `fetch_support_admin_set()` performs the I/O.
 
+### 3.6 New endpoint: `GET /api/admin/team-lookup`
+
+The primary search surface for the Restaurant app's "Open another restaurant" picker (§5.2). Lets a support agent find a restaurant by name rather than going through the owner.
+
+**Auth**: `is_support_admin()` only. Tenant-scoped via `TenantExtractor`.
+
+**Query params**:
+
+| Param | Description |
+|---|---|
+| `q` | Required. Case-insensitive substring of the team name. Minimum 2 characters. |
+
+**Response**:
+
+```json
+{
+  "results": [
+    {
+      "id": 17,
+      "name": "Joe's Diner",
+      "admin_emails": ["joe@example.com"],
+      "has_stored_key": true,
+      "created_at": "2025-09-12T14:03:11Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+**Behavior**:
+
+- Single SQL query with `ILIKE '%q%'` on `teams.name`, joined to `team_users` and `users` to aggregate admin emails (deduped, admins only — `member` rows are excluded), and an `EXISTS` subquery against `stored_keys` for the provisioning flag.
+- Results are tenant-scoped, sorted by name, capped at **25 rows** (`TEAM_LOOKUP_LIMIT`).
+- Queries shorter than 2 chars return 400; this is intentional — too short to render in a picker without overwhelming.
+- `has_stored_key: false` rows are still returned so the client can show the team but disable the "Open" action with a message ("not yet provisioned"); per §3.2, `POST /support-access` would 400 on those teams.
+
+**Why a name search rather than user-rooted**: support agents most often start from "this restaurant has a problem," not "this user has a problem." The owner-rooted `user-lookup` + `user-teams` flow is retained for the cases that genuinely begin from a user (claim-token lookup, revoking a specific user's authorizations) but is no longer the primary path for finding a restaurant.
+
 ---
 
 ## 4. Reused Surface (no changes)


### PR DESCRIPTION
## Summary

Adds the primary search endpoint for the Restaurant app's "Open another restaurant" picker. Support agents can find a restaurant by typing its name instead of having to know the owner's email or pubkey first.

The owner-rooted `user-lookup` + `user-teams` flow stays in place for tools that genuinely start from a user (claim-token lookup, per-user authorization revocation), but it's no longer the primary path for "find a restaurant."

## Endpoint

```
GET /api/admin/team-lookup?q=<name>
```

- **Auth**: `is_support_admin` only (matches the rest of the support surface).
- **Tenant-scoped** via `TenantExtractor`.
- **Query**: `q` — case-insensitive substring of the team name. Minimum 2 chars (shorter queries return 400).
- **Limit**: 25 results, sorted by name.

**Response**:
```json
{
  "results": [
    {
      "id": 17,
      "name": "Joe's Diner",
      "admin_emails": ["joe@example.com"],
      "has_stored_key": true,
      "created_at": "2025-09-12T14:03:11Z"
    }
  ],
  "total": 1
}
```

`admin_emails` is deduped and includes only `admin`-role members (members are excluded). `has_stored_key: false` rows are still returned so the client can show the restaurant with a disabled "Open" action and explain why (per §3.2 the team isn't yet eligible for `support-access`).

## Implementation

- New [`TeamRepository::search_by_name`](core/src/repositories/team.rs) returning `TeamSearchResult`. Single SQL using `ILIKE`, joined to `team_users` + `users` for admin-email aggregation and `EXISTS` for the stored-key flag.
- New [`get_team_lookup`](api/src/api/http/admin.rs) handler with `TeamLookupQuery` / `TeamLookupResponse` / `TeamLookupCandidate`.
- Route registered alongside `user-lookup` in [`routes.rs`](api/src/api/http/routes.rs).
- New §3.6 in [`docs/synvya/support-users.md`](docs/synvya/support-users.md) documents the endpoint.

## Tests

Repository-level integration tests in [`api/tests/admin_team_lookup_test.rs`](api/tests/admin_team_lookup_test.rs):

- `test_search_matches_substring_case_insensitive` — `ILIKE` finds the right team, ignores unrelated names.
- `test_search_aggregates_admin_emails` — multiple admins → deduped emails; non-admin member is excluded.
- `test_search_has_stored_key_flag` — true when present, false when absent.
- `test_search_is_tenant_scoped` — same-named teams in different tenants don't leak across the boundary.
- `test_search_respects_limit` — 5 matching rows + limit=3 → returns 3.

## Companion work

A small client spec update in `Synvya/client` will swap §3.3 of `docs/specs/support-users.md` to reflect this new primary search path. I'll send that as a separate PR after this lands.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p keycast_api -p keycast_core --all-targets -- -D warnings`
- [x] `cargo check -p keycast_api --tests --features integration-tests`
- [ ] CI runs the integration tests against the test database.
- [ ] Manual on staging:
  - [ ] As a support admin, `GET /api/admin/team-lookup?q=joe` returns matching teams with admin emails and `has_stored_key`.
  - [ ] As a non-support, non-full user, returns 403.
  - [ ] `q` shorter than 2 chars returns 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)