### PR TITLE
fix(tests): repair admin_team_lookup_test fixtures (CI failures from #57)

### DIFF
--- a/api/tests/admin_team_lookup_test.rs
+++ b/api/tests/admin_team_lookup_test.rs
@@ -32,29 +32,36 @@ async fn setup_pool() -> PgPool {
 }
 
 async fn ensure_tenant(pool: &PgPool, tenant_id: i64) {
-    let _ = sqlx::query(
-        "INSERT INTO tenants (id, name, created_at, updated_at)
-         VALUES ($1, $2, NOW(), NOW())
+    // The tenants table requires (id, domain, name) — domain is NOT NULL.
+    sqlx::query(
+        "INSERT INTO tenants (id, domain, name, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())
          ON CONFLICT (id) DO NOTHING",
     )
     .bind(tenant_id)
+    .bind(format!("test-tenant-{}.example.test", tenant_id))
     .bind(format!("test-tenant-{}", tenant_id))
     .execute(pool)
-    .await;
+    .await
+    .expect("ensure_tenant insert must succeed");
 }
 
-/// Create a user with optional email. Idempotent on (pubkey, tenant_id).
+/// Create or update a user with optional email. The unique index on `users`
+/// is on `pubkey` alone (`users_pubkey_idx`), not `(pubkey, tenant_id)`.
 async fn ensure_user_with_email(pool: &PgPool, tenant_id: i64, pubkey: &str, email: Option<&str>) {
-    let _ = sqlx::query(
+    sqlx::query(
         "INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at)
          VALUES ($1, $2, $3, NOW(), NOW())
-         ON CONFLICT (pubkey, tenant_id) DO UPDATE SET email = EXCLUDED.email",
+         ON CONFLICT (pubkey) DO UPDATE
+             SET email = EXCLUDED.email,
+                 tenant_id = EXCLUDED.tenant_id",
     )
     .bind(pubkey)
     .bind(tenant_id)
     .bind(email)
     .execute(pool)
-    .await;
+    .await
+    .expect("ensure_user_with_email insert must succeed");
 }
 
 /// Create a team with the given admin and (optionally) a stored key. Returns team_id.
@@ -125,15 +132,19 @@ async fn test_search_matches_substring_case_insensitive() {
     let pool = setup_pool().await;
     let admin = Keys::generate().public_key().to_hex();
     let unique = Uuid::new_v4().to_string();
-    let target_name = format!("Joes Diner {}", unique);
-    let unrelated_name = format!("Bella Bistro {}", unique);
+    // Two teams; target name carries an uppercase prefix so we can verify the
+    // case-insensitive match. The disambiguating substring lives at the start.
+    let target_name = format!("JoesDiner-{}", unique);
+    let unrelated_name = format!("BellaBistro-{}", unique);
 
     let target = create_team(&pool, TENANT_A, &target_name, &admin, true).await;
     let unrelated = create_team(&pool, TENANT_A, &unrelated_name, &admin, true).await;
 
     let team_repo = TeamRepository::new(pool.clone());
+    // Lowercase substring of the target name. Must match `JoesDiner-…`
+    // case-insensitively and must NOT match `BellaBistro-…`.
     let results = team_repo
-        .search_by_name(TENANT_A, &format!("joes {}", &unique[..8]), 25)
+        .search_by_name(TENANT_A, &format!("joesdiner-{}", &unique[..8]), 25)
         .await
         .expect("search should succeed");
 


### PR DESCRIPTION
## Summary

Fixes the three CI failures from the post-merge deploy of [#57](https://github.com/Synvya/keycast/pull/57). All three are bugs in the test file itself, not in production code. The new endpoint and repository helper are unaffected.

## Failures and fixes

| Test | Failure | Fix |
|---|---|---|
| `test_search_matches_substring_case_insensitive` | "target team must be in results" — team name `\"Joes Diner {uuid}\"` and query `\"joes {uuid[..8]}\"` don't share a contiguous substring (`\"Diner \"` sits between them). | Rename teams to `\"JoesDiner-{uuid}\"` so a single substring match works. |
| `test_search_aggregates_admin_emails` | FK violation on `team_users_user_pubkey_fkey`. The unique constraint on `users` is on `pubkey` alone (`users_pubkey_idx`), not `(pubkey, tenant_id)`, so the `ON CONFLICT (pubkey, tenant_id)` in `ensure_user_with_email` was a hard parse error that `let _ = ...` was silently swallowing. | Use `ON CONFLICT (pubkey) DO UPDATE`. |
| `test_search_is_tenant_scoped` | FK violation on `users_tenant_id_fkey`. The `tenants` table requires `domain text NOT NULL`, but `ensure_tenant` only supplied `(id, name)`, so the insert silently failed and tenant 999_001 never existed. | Add the `domain` column to the insert. |

Also replaces the `let _ = ...` error-swallowing in both fixture helpers with `.expect(...)` so future bugs fail loudly at the call site rather than cascading into mysterious downstream FK errors.

## Why this wasn't caught locally

I had no local Postgres available before pushing #57 — the new tests couldn't actually run. Compile-clean and clippy-clean, but the SQL bugs only surfaced once CI ran them against a live database. Lesson learned for future PRs touching repository tests.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p keycast_api --tests --features integration-tests -- -D warnings`
- [x] `cargo check -p keycast_api --tests --features integration-tests`
- [ ] CI runs the integration tests against the test database — should now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)