### PR TITLE
Promote synvya-staging to production

### DIFF
--- a/api/src/api/extractors.rs
+++ b/api/src/api/extractors.rs
@@ -15,6 +15,12 @@ pub struct AuthError {
     message: String,
 }
 
+impl AuthError {
+    pub fn new(status: StatusCode, message: String) -> Self {
+        Self { status, message }
+    }
+}
+
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         let body = serde_json::json!({ "error": self.message });
@@ -42,6 +48,13 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let path = parts.uri.path();
+
+        // Try 0: NIP-98 service-auth (Authorization: Nostr <base64>).
+        // Exclusive — if the header is present, this path either succeeds
+        // or the request is rejected. No fall-through to Bearer/cookie.
+        if let Some(result) = crate::api::nip98_extractor::try_authenticate_nip98(parts).await {
+            return result;
+        }
 
         // Try 1: UCAN Bearer Token
         if let Some(auth_header) = parts.headers.get("Authorization") {

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -16,7 +16,7 @@ use crate::state::{get_key_manager, get_secret_pool};
 use keycast_core::bunker_key::derive_bunker_keys;
 use keycast_core::repositories::{
     AuthorizationRepository, ClaimTokenRepository, OAuthAuthorizationRepository, PolicyRepository,
-    StoredKeyRepository, TeamRepository, UserRepository,
+    StoredKeyRepository, TeamRepository, TeamSearchResult, UserRepository,
 };
 use keycast_core::types::authorization::Authorization;
 use keycast_core::types::claim_token::generate_claim_token;
@@ -930,6 +930,94 @@ pub async fn get_user_lookup(
     }
 
     Ok(Json(UserLookupResponse { results, total }))
+}
+
+// ============================================================================
+// GET /api/admin/team-lookup?q=<name> - Search teams by name
+// ============================================================================
+
+/// Maximum number of teams returned by `team-lookup`. Tight enough to render
+/// inline in a picker without scroll; loose enough to disambiguate when many
+/// restaurants share a common word (e.g. "pizza").
+const TEAM_LOOKUP_LIMIT: i64 = 25;
+
+/// Minimum query length before the server runs the search. Shorter queries
+/// would match too many teams to be useful in a picker.
+const TEAM_LOOKUP_MIN_QUERY_LEN: usize = 2;
+
+#[derive(Debug, Deserialize)]
+pub struct TeamLookupQuery {
+    /// Case-insensitive substring of the team name. Required.
+    pub q: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TeamLookupResponse {
+    pub results: Vec<TeamLookupCandidate>,
+    pub total: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TeamLookupCandidate {
+    pub id: i32,
+    pub name: String,
+    /// Emails of admins on the team (deduped). May be empty if no admin has
+    /// an email on file. Useful for disambiguating same-named restaurants.
+    pub admin_emails: Vec<String>,
+    /// `true` if the team has at least one stored key. A team with no stored
+    /// key is not eligible for `POST /admin/teams/:id/support-access`; the
+    /// client should surface this so support agents see why.
+    pub has_stored_key: bool,
+    pub created_at: String,
+}
+
+impl From<TeamSearchResult> for TeamLookupCandidate {
+    fn from(row: TeamSearchResult) -> Self {
+        Self {
+            id: row.id,
+            name: row.name,
+            admin_emails: row.admin_emails,
+            has_stored_key: row.has_stored_key,
+            created_at: row.created_at.to_rfc3339(),
+        }
+    }
+}
+
+/// Look up teams by case-insensitive name substring. Available to support
+/// admins and above. Tenant-scoped. Returns up to 25 candidates with admin
+/// emails and provisioning status to drive the Restaurant app's
+/// "Open another restaurant" search picker.
+pub async fn get_team_lookup(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    axum::extract::Query(query): axum::extract::Query<TeamLookupQuery>,
+) -> ApiResult<Json<TeamLookupResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Support admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+
+    let q = query.q.trim();
+    if q.len() < TEAM_LOOKUP_MIN_QUERY_LEN {
+        return Err(ApiError::bad_request(format!(
+            "Query 'q' must be at least {} characters",
+            TEAM_LOOKUP_MIN_QUERY_LEN
+        )));
+    }
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let rows = team_repo
+        .search_by_name(tenant_id, q, TEAM_LOOKUP_LIMIT)
+        .await
+        .map_err(|e| ApiError::internal(format!("Team search failed: {}", e)))?;
+
+    let results: Vec<TeamLookupCandidate> = rows.into_iter().map(Into::into).collect();
+    let total = results.len();
+
+    Ok(Json(TeamLookupResponse { results, total }))
 }
 
 // ============================================================================

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -725,7 +725,18 @@ pub async fn batch_create_claim_tokens(
             }
         };
 
-        let claim_url = format!("{}/api/claim?token={}", app_url, token);
+        // Pre-fill the recipient's email on the claim form when we know it.
+        // Convenience only — the user can edit it, and claim_post does not
+        // enforce a match. See docs/synvya/admin-user-provisioning.md.
+        let claim_url = match &req.delivery_email {
+            Some(email) => format!(
+                "{}/api/claim?token={}&email={}",
+                app_url,
+                token,
+                urlencoding::encode(email)
+            ),
+            None => format!("{}/api/claim?token={}", app_url, token),
+        };
 
         // Send email if requested
         if let (Some(email), Some(svc)) = (&req.delivery_email, &email_service) {

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -7,12 +7,18 @@ use chrono::{Duration, Utc};
 use nostr_sdk::{FromBech32, Keys};
 use serde::{Deserialize, Serialize};
 
+use secrecy::ExposeSecret;
+
 use super::routes::AuthState;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extractors::UcanAuth;
+use crate::state::{get_key_manager, get_secret_pool};
+use keycast_core::bunker_key::derive_bunker_keys;
 use keycast_core::repositories::{
-    ClaimTokenRepository, OAuthAuthorizationRepository, UserRepository,
+    AuthorizationRepository, ClaimTokenRepository, OAuthAuthorizationRepository, PolicyRepository,
+    StoredKeyRepository, TeamRepository, UserRepository,
 };
+use keycast_core::types::authorization::Authorization;
 use keycast_core::types::claim_token::generate_claim_token;
 
 /// Admin token expiry in days (30 days for long-lived admin tokens)
@@ -23,6 +29,12 @@ const PRELOAD_TOKEN_EXPIRY_DAYS: i64 = 30;
 
 /// Redis key for the support admins set
 const SUPPORT_ADMINS_KEY: &str = "support_admins";
+
+/// Default expiry for support-issued authorizations (§8.2 of support-users.md).
+const DEFAULT_SUPPORT_AUTH_EXPIRY_HOURS: i64 = 24;
+
+/// Server-enforced ceiling on support-issued authorization lifetime.
+const MAX_SUPPORT_AUTH_EXPIRY_HOURS: i64 = 24 * 7;
 
 /// Full admin: has admin_role == "full" in UCAN, or pubkey in ALLOWED_PUBKEYS whitelist.
 /// Full admins can access all admin endpoints including token generation and user preloading.
@@ -1173,6 +1185,294 @@ pub async fn revoke_authorization(
     Ok(Json(RevokeAuthorizationResponse {
         revoked: true,
         authorization_id,
+    }))
+}
+
+// ============================================================================
+// POST /api/admin/teams/:id/support-access — JIT membership on a team
+// ============================================================================
+
+#[derive(Debug, Default, Deserialize)]
+pub struct GrantSupportAccessRequest {
+    /// Optional policy id; defaults to the team's first policy ("All Access").
+    #[serde(default)]
+    pub policy_id: Option<i32>,
+    /// Optional human-readable suffix for audit clarity. The server always
+    /// prefixes with `support:{caller_pubkey_hex}` regardless of input — the
+    /// prefix is the source of truth for the release endpoint's filter.
+    #[serde(default)]
+    pub label: Option<String>,
+    /// Optional authorization lifetime in hours. Defaults to 24, capped at 168.
+    #[serde(default)]
+    pub expires_in_hours: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GrantSupportAccessResponse {
+    pub team_id: i32,
+    pub stored_key_pubkey: String,
+    pub authorization: Authorization,
+    pub bunker_url: String,
+}
+
+/// Add the calling support admin as a `member` of the team (idempotent — admin
+/// rows are preserved), mint a fresh authorization against the team's stored
+/// key, and return the bunker URL. See `docs/synvya/support-users.md` §3.2.
+pub async fn grant_team_support_access(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Path(team_id): Path<i32>,
+    Json(req): Json<GrantSupportAccessRequest>,
+) -> ApiResult<Json<GrantSupportAccessResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Support admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+    let caller = &auth.pubkey;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    team_repo
+        .find(tenant_id, team_id)
+        .await
+        .map_err(|_| ApiError::not_found("Team not found"))?;
+
+    let key_repo = StoredKeyRepository::new(pool.clone());
+    let stored_keys = key_repo
+        .list_by_team(tenant_id, team_id)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to load stored keys: {}", e)))?;
+
+    let stored_key = stored_keys.into_iter().next().ok_or_else(|| {
+        ApiError::bad_request(
+            "team has no stored key — the agent who created it must finish provisioning first",
+        )
+    })?;
+
+    let policy_repo = PolicyRepository::new(pool.clone());
+    let policy_id = match req.policy_id {
+        Some(id) => {
+            if !policy_repo
+                .exists_for_team(team_id, id)
+                .await
+                .map_err(|e| ApiError::internal(format!("Failed to verify policy: {}", e)))?
+            {
+                return Err(ApiError::not_found("Policy not found for this team"));
+            }
+            id
+        }
+        None => {
+            policy_repo
+                .list_by_team(team_id)
+                .await
+                .map_err(|e| ApiError::internal(format!("Failed to load policies: {}", e)))?
+                .into_iter()
+                .next()
+                .ok_or_else(|| ApiError::internal("Team has no policies"))?
+                .id
+        }
+    };
+
+    if !team_repo
+        .is_member(team_id, caller)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to check membership: {}", e)))?
+    {
+        team_repo
+            .add_member(team_id, caller, "member")
+            .await
+            .map_err(|e| ApiError::internal(format!("Failed to add support member: {}", e)))?;
+    }
+
+    let secret_pool = get_secret_pool().map_err(|e| ApiError::internal(e.to_string()))?;
+    let secret_pair = secret_pool
+        .get()
+        .await
+        .ok_or_else(|| ApiError::internal("Secret pool exhausted".to_string()))?;
+    let connection_secret = secret_pair.secret;
+    let secret_hash = secret_pair.hash;
+
+    let key_manager = get_key_manager().map_err(|e| ApiError::internal(e.to_string()))?;
+    let decrypted_stored_key = key_manager
+        .decrypt(&stored_key.secret_key)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to decrypt stored key: {}", e)))?;
+    let stored_key_secret = nostr_sdk::SecretKey::from_slice(&decrypted_stored_key)
+        .map_err(|e| ApiError::internal(format!("Invalid stored key: {}", e)))?;
+    let bunker_keys = derive_bunker_keys(&stored_key_secret, &secret_hash);
+
+    let relays = serde_json::json!(Vec::<String>::new());
+
+    let hours = req
+        .expires_in_hours
+        .unwrap_or(DEFAULT_SUPPORT_AUTH_EXPIRY_HOURS)
+        .clamp(1, MAX_SUPPORT_AUTH_EXPIRY_HOURS);
+    let expires_at = Utc::now() + Duration::hours(hours);
+
+    let label = match req
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(suffix) => format!("support:{} ({})", caller, suffix),
+        None => format!("support:{}", caller),
+    };
+
+    let auth_repo = AuthorizationRepository::new(pool.clone());
+    let authorization = auth_repo
+        .create(
+            tenant_id,
+            stored_key.id,
+            policy_id,
+            &secret_hash,
+            &bunker_keys.public_key().to_hex(),
+            &relays,
+            None,
+            Some(expires_at),
+            Some(&label),
+        )
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to create authorization: {}", e)))?;
+
+    let bunker_url = Authorization::generate_bunker_url(
+        &bunker_keys.public_key().to_hex(),
+        connection_secret.expose_secret(),
+    );
+
+    if let Some(tx) = &auth_state.auth_tx {
+        use keycast_core::authorization_channel::AuthorizationCommand;
+        if let Err(e) = tx
+            .send(AuthorizationCommand::Upsert {
+                bunker_pubkey: bunker_keys.public_key().to_hex(),
+                tenant_id,
+                is_oauth: false,
+            })
+            .await
+        {
+            tracing::warn!(
+                "Failed to notify signer of support-access grant for {}: {}",
+                bunker_keys.public_key().to_hex(),
+                e
+            );
+        }
+    }
+
+    tracing::info!(
+        "Support access granted: team={} support_admin={} authorization={}",
+        team_id,
+        &caller[..8.min(caller.len())],
+        authorization.id,
+    );
+
+    Ok(Json(GrantSupportAccessResponse {
+        team_id,
+        stored_key_pubkey: stored_key.pubkey.clone(),
+        authorization,
+        bunker_url,
+    }))
+}
+
+// ============================================================================
+// DELETE /api/admin/teams/:id/support-access — release JIT membership
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub struct ReleaseSupportAccessResponse {
+    pub team_id: i32,
+    pub revoked_authorizations: usize,
+    pub removed_membership: bool,
+}
+
+/// Revoke the calling support admin's active authorizations on the team
+/// (identified by the `support:{caller}` label prefix) and remove their
+/// `member` row. Admin rows are preserved. See §3.3.
+pub async fn release_team_support_access(
+    tenant: crate::api::tenant::TenantExtractor,
+    State(auth_state): State<AuthState>,
+    auth: UcanAuth,
+    Path(team_id): Path<i32>,
+) -> ApiResult<Json<ReleaseSupportAccessResponse>> {
+    if !is_support_admin(&auth).await {
+        return Err(ApiError::forbidden("Support admin access required"));
+    }
+
+    let tenant_id = tenant.0.id;
+    let pool = &auth_state.state.db;
+    let caller = &auth.pubkey;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    team_repo
+        .find(tenant_id, team_id)
+        .await
+        .map_err(|_| ApiError::not_found("Team not found"))?;
+
+    let auth_repo = AuthorizationRepository::new(pool.clone());
+    let active = auth_repo
+        .find_active_support_for_caller(tenant_id, team_id, caller)
+        .await
+        .map_err(|e| ApiError::internal(format!("Failed to load support authorizations: {}", e)))?;
+
+    let mut revoked_count = 0usize;
+    for (auth_id, bunker_pubkey) in &active {
+        let bunker_pubkey_revoked = auth_repo
+            .revoke(tenant_id, *auth_id, Some("support_session_end"))
+            .await
+            .map_err(|e| ApiError::internal(format!("Failed to revoke authorization: {}", e)))?;
+
+        if bunker_pubkey_revoked.is_none() {
+            // Already revoked between the lookup and now — skip the daemon notify.
+            continue;
+        }
+        revoked_count += 1;
+
+        if let Some(tx) = &auth_state.auth_tx {
+            use keycast_core::authorization_channel::AuthorizationCommand;
+            if let Err(e) = tx
+                .send(AuthorizationCommand::Remove {
+                    bunker_pubkey: bunker_pubkey.clone(),
+                })
+                .await
+            {
+                tracing::warn!(
+                    "Failed to notify signer of support-access release for {}: {}",
+                    bunker_pubkey,
+                    e
+                );
+            }
+        }
+    }
+
+    let mut removed_membership = false;
+    match team_repo.get_member(team_id, caller).await {
+        Ok(member) if matches!(member.role, keycast_core::types::user::TeamUserRole::Member) => {
+            team_repo
+                .remove_member(team_id, caller)
+                .await
+                .map_err(|e| ApiError::internal(format!("Failed to remove member: {}", e)))?;
+            removed_membership = true;
+        }
+        Ok(_) => {
+            // Caller is admin (e.g., they created this team) — leave the row.
+        }
+        Err(_) => {
+            // No membership row (idempotent re-call) — nothing to remove.
+        }
+    }
+
+    tracing::info!(
+        "Support access released: team={} support_admin={} revoked={}",
+        team_id,
+        &caller[..8.min(caller.len())],
+        revoked_count,
+    );
+
+    Ok(Json(ReleaseSupportAccessResponse {
+        team_id,
+        revoked_authorizations: revoked_count,
+        removed_membership,
     }))
 }
 

--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -28,7 +28,7 @@ const ADMIN_TOKEN_EXPIRY_DAYS: i64 = 30;
 const PRELOAD_TOKEN_EXPIRY_DAYS: i64 = 30;
 
 /// Redis key for the support admins set
-const SUPPORT_ADMINS_KEY: &str = "support_admins";
+pub const SUPPORT_ADMINS_KEY: &str = "support_admins";
 
 /// Default expiry for support-issued authorizations (§8.2 of support-users.md).
 const DEFAULT_SUPPORT_AUTH_EXPIRY_HOURS: i64 = 24;

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -75,7 +75,7 @@ pub async fn claim_get(
     let prefill_email = params.email.as_deref().unwrap_or("");
 
     let html = format!(
-        r#"<!DOCTYPE html>
+        r##"<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -101,6 +101,12 @@ pub async fn claim_get(
             max-width: 400px;
             width: 100%;
             box-shadow: 0 8px 32px rgba(39, 197, 139, 0.08);
+        }}
+        .logo {{
+            width: 140px;
+            height: auto;
+            display: block;
+            margin: 0 auto 24px;
         }}
         h1 {{
             margin: 0 0 8px 0;
@@ -193,6 +199,16 @@ pub async fn claim_get(
 </head>
 <body>
     <div class="container">
+        <svg class="logo" viewBox="0 0 240 100" xmlns="http://www.w3.org/2000/svg" aria-label="Synvya">
+            <g fill="#1DB054">
+                <rect x="20" y="60" width="45" height="6" rx="3" />
+                <path d="M25 58 C25 35 60 35 60 58 Z" />
+                <circle cx="42.5" cy="36" r="3" />
+                <path d="M68 48 L78 58 L68 68 V62 H58 V54 H68 V48 Z" />
+            </g>
+            <text x="90" y="62" font-family="Arial, sans-serif" font-size="42" fill="#1DB054" font-weight="400">Synvya</text>
+        </svg>
+
         <h1>Claim Your Account</h1>
         <p class="welcome">Set up your login credentials to access your account.</p>
 
@@ -242,7 +258,7 @@ pub async fn claim_get(
         }}
     </script>
 </body>
-</html>"#,
+</html>"##,
         display_name = html_escape(&display_name_str),
         username = html_escape(&username_str),
         token = html_escape(&params.token),
@@ -358,9 +374,16 @@ pub async fn claim_post(
 
     let display_name_str = display_name.unwrap_or_else(|| username.clone().unwrap_or_default());
 
-    // Show success page with app download instructions
+    // Where to send the recipient after they've claimed. Synvya admin onboarding
+    // is the only flow that hits this success page today (Vine import is legacy).
+    // Set in scripts/load-secrets.sh per environment; safe default keeps the
+    // page valid in dev / unset configurations.
+    let admin_base_url =
+        std::env::var("ADMIN_BASE_URL").unwrap_or_else(|_| "https://admin.synvya.com".to_string());
+
+    // Show success page directing the new admin to Synvya Admin.
     let html = format!(
-        r#"<!DOCTYPE html>
+        r##"<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -388,6 +411,12 @@ pub async fn claim_post(
             text-align: center;
             box-shadow: 0 8px 32px rgba(39, 197, 139, 0.08);
         }}
+        .logo {{
+            width: 140px;
+            height: auto;
+            display: block;
+            margin: 0 auto 28px;
+        }}
         .checkmark {{
             width: 56px;
             height: 56px;
@@ -411,65 +440,6 @@ pub async fn claim_post(
             margin: 0 0 28px 0;
             line-height: 1.5;
         }}
-        .steps {{
-            text-align: left;
-            margin-bottom: 28px;
-        }}
-        .step {{
-            display: flex;
-            gap: 14px;
-            align-items: flex-start;
-            margin-bottom: 18px;
-        }}
-        .step-num {{
-            flex-shrink: 0;
-            width: 28px;
-            height: 28px;
-            background: rgba(39, 197, 139, 0.15);
-            color: #27C58B;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 13px;
-            font-weight: 700;
-        }}
-        .step-content {{
-            flex: 1;
-        }}
-        .step-title {{
-            color: #F9F7F6;
-            font-weight: 600;
-            font-size: 14px;
-            margin-bottom: 3px;
-        }}
-        .step-desc {{
-            color: #9CA3AF;
-            font-size: 13px;
-            line-height: 1.4;
-        }}
-        .app-links {{
-            display: flex;
-            gap: 10px;
-            margin-top: 8px;
-        }}
-        .app-link {{
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            padding: 8px 14px;
-            background: #072218;
-            border: 1px solid #1C4033;
-            border-radius: 8px;
-            color: #F9F7F6;
-            text-decoration: none;
-            font-size: 13px;
-            font-weight: 500;
-            transition: border-color 0.2s;
-        }}
-        .app-link:hover {{
-            border-color: #27C58B;
-        }}
         .divider {{
             border-top: 1px solid #1C4033;
             margin: 0 0 20px 0;
@@ -490,62 +460,56 @@ pub async fn claim_post(
         .web-link:hover {{
             background: #1AA575;
         }}
+        .instruction {{
+            color: #BEB3A7;
+            font-size: 14px;
+            line-height: 1.5;
+            margin: 0 0 24px 0;
+        }}
         .note {{
             color: #9CA3AF;
             font-size: 12px;
-            margin-top: 16px;
+            margin-top: 20px;
             line-height: 1.4;
+        }}
+        .note a {{
+            color: #27C58B;
+            text-decoration: none;
+        }}
+        .note a:hover {{
+            text-decoration: underline;
         }}
     </style>
 </head>
 <body>
     <div class="container">
+        <svg class="logo" viewBox="0 0 240 100" xmlns="http://www.w3.org/2000/svg" aria-label="Synvya">
+            <g fill="#1DB054">
+                <rect x="20" y="60" width="45" height="6" rx="3" />
+                <path d="M25 58 C25 35 60 35 60 58 Z" />
+                <circle cx="42.5" cy="36" r="3" />
+                <path d="M68 48 L78 58 L68 68 V62 H58 V54 H68 V48 Z" />
+            </g>
+            <text x="90" y="62" font-family="Arial, sans-serif" font-size="42" fill="#1DB054" font-weight="400">Synvya</text>
+        </svg>
+
         <div class="checkmark">&#10003;</div>
         <h1>Account Claimed!</h1>
         <p class="subtitle">Welcome, {display_name}. Your credentials have been set.</p>
 
-        <div class="steps">
-            <div class="step">
-                <div class="step-num">1</div>
-                <div class="step-content">
-                    <div class="step-title">Get the App</div>
-                    <div class="step-desc">Download Synvya for the best experience.</div>
-                    <div class="app-links">
-                        <a class="app-link" href="https://apps.apple.com/app/divine-video/id6744577425" target="_blank">
-                            &#63743; App Store
-                        </a>
-                        <a class="app-link" href="https://play.google.com/store/apps/details?id=com.openvine.divine" target="_blank">
-                            &#9654; Google Play
-                        </a>
-                    </div>
-                </div>
-            </div>
-            <div class="step">
-                <div class="step-num">2</div>
-                <div class="step-content">
-                    <div class="step-title">Sign In</div>
-                    <div class="step-desc">Use the email and password you just set to sign in.</div>
-                </div>
-            </div>
-            <div class="step">
-                <div class="step-num">3</div>
-                <div class="step-content">
-                    <div class="step-title">Your Content is Waiting</div>
-                    <div class="step-desc">Your videos and profile are ready to go.</div>
-                </div>
-            </div>
-        </div>
-
         <div class="divider"></div>
 
-        <a class="web-link" href="https://divine.video" target="_blank">
-            Open Synvya on Web
+        <p class="instruction">Use the email and password you just set to sign in to Synvya Admin.</p>
+
+        <a class="web-link" href="{admin_base_url}">
+            Open Synvya Admin
         </a>
-        <p class="note">You can also access your account at divine.video</p>
+        <p class="note">Need help? Contact <a href="mailto:support@synvya.com">support@synvya.com</a></p>
     </div>
 </body>
-</html>"#,
+</html>"##,
         display_name = html_escape(&display_name_str),
+        admin_base_url = html_escape(&admin_base_url),
     );
 
     Ok(([(header::SET_COOKIE, cookie_value)], Html(html)).into_response())

--- a/api/src/api/http/claim.rs
+++ b/api/src/api/http/claim.rs
@@ -26,6 +26,13 @@ fn get_server_keys() -> Result<Keys, ClaimError> {
 #[derive(Debug, Deserialize)]
 pub struct ClaimQuery {
     pub token: String,
+    /// Optional pre-fill for the email input. Set by callers that already
+    /// know the recipient's email (e.g. claim-tokens/batch with
+    /// `delivery_email`). Convenience only: the user can edit the value
+    /// in the form, and `claim_post` does not enforce a match. See
+    /// `docs/synvya/admin-user-provisioning.md` for the design rationale.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 /// Form data for POST /claim
@@ -65,6 +72,7 @@ pub async fn claim_get(
 
     let display_name_str = display_name.unwrap_or_else(|| username.clone().unwrap_or_default());
     let username_str = username.unwrap_or_default();
+    let prefill_email = params.email.as_deref().unwrap_or("");
 
     let html = format!(
         r#"<!DOCTYPE html>
@@ -199,7 +207,7 @@ pub async fn claim_get(
             <input type="hidden" name="token" value="{token}">
 
             <label for="email">Email</label>
-            <input type="email" id="email" name="email" required placeholder="your@email.com">
+            <input type="email" id="email" name="email" required placeholder="your@email.com" value="{email}">
 
             <label for="password">Password</label>
             <input type="password" id="password" name="password" required placeholder="••••••••" minlength="8">
@@ -238,6 +246,7 @@ pub async fn claim_get(
         display_name = html_escape(&display_name_str),
         username = html_escape(&username_str),
         token = html_escape(&params.token),
+        email = html_escape(prefill_email),
     );
 
     Ok(Html(html).into_response())

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -203,6 +203,10 @@ pub fn api_routes(
             post(admin::revoke_authorization),
         )
         .route(
+            "/admin/teams/:id/support-access",
+            post(admin::grant_team_support_access).delete(admin::release_team_support_access),
+        )
+        .route(
             "/admin/support-admins",
             get(admin::list_support_admins).post(admin::add_support_admin),
         )

--- a/api/src/api/http/routes.rs
+++ b/api/src/api/http/routes.rs
@@ -198,6 +198,7 @@ pub fn api_routes(
         )
         .route("/admin/user-lookup", get(admin::get_user_lookup))
         .route("/admin/user-teams", get(admin::get_user_teams))
+        .route("/admin/team-lookup", get(admin::get_team_lookup))
         .route(
             "/admin/authorizations/:id/revoke",
             post(admin::revoke_authorization),

--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -65,7 +65,10 @@ pub async fn create_team(
         .await?
         == 0;
 
-    if !super::admin::is_full_admin(&auth) && !can_create_first_team {
+    let is_full = super::admin::is_full_admin(&auth);
+    let is_support = !is_full && super::admin::is_support_admin(&auth).await;
+
+    if !is_full && !is_support && !can_create_first_team {
         tracing::warn!(
             "Team creation denied for non-admin pubkey: {}",
             user_pubkey_hex
@@ -87,6 +90,15 @@ pub async fn create_team(
             allowed_kinds_config,
         )
         .await?;
+
+    if is_support {
+        tracing::info!(
+            "Team created by support admin: team_id={} support_admin={} name={}",
+            team_with_relations.team.id,
+            &user_pubkey_hex[..8.min(user_pubkey_hex.len())],
+            request.name,
+        );
+    }
 
     Ok(Json(team_with_relations))
 }

--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -24,6 +24,34 @@ use keycast_core::types::stored_key::PublicStoredKey;
 use keycast_core::types::team::{KeyWithRelations, Team, TeamWithRelations};
 use keycast_core::types::user::{TeamUser, TeamUserRole};
 
+/// Fetch the Redis `support_admins` set as a `HashSet`. Returns `None` when
+/// state or Redis is unavailable; callers should treat that as "no enrichment
+/// possible" and fall back to default `is_support_member: false` on responses.
+async fn fetch_support_admin_set() -> Option<std::collections::HashSet<String>> {
+    let state = crate::state::get_keycast_state().ok()?;
+    let redis = state.redis.as_ref()?;
+    match redis.smembers(super::admin::SUPPORT_ADMINS_KEY).await {
+        Ok(v) => Some(v.into_iter().collect()),
+        Err(e) => {
+            tracing::warn!("Redis SMEMBERS support_admins failed: {}", e);
+            None
+        }
+    }
+}
+
+/// Stamp `is_support_member: true` on each `TeamUser` whose pubkey appears in
+/// the supplied `support_admins` set. Pure function — exposed for unit tests.
+pub(crate) fn mark_support_members(
+    team_users: &mut [TeamUser],
+    support_set: &std::collections::HashSet<String>,
+) {
+    for tu in team_users.iter_mut() {
+        if support_set.contains(&tu.user_pubkey) {
+            tu.is_support_member = true;
+        }
+    }
+}
+
 pub async fn list_teams(
     tenant: crate::api::tenant::TenantExtractor,
     State(pool): State<PgPool>,
@@ -43,7 +71,15 @@ pub async fn list_teams(
         .await
         .map_err(|_| ApiError::not_found("User not found"))?;
 
-    let teams_with_relations = user.teams(&pool, tenant_id).await?;
+    let mut teams_with_relations = user.teams(&pool, tenant_id).await?;
+
+    if !teams_with_relations.is_empty() {
+        if let Some(set) = fetch_support_admin_set().await {
+            for twr in teams_with_relations.iter_mut() {
+                mark_support_members(&mut twr.team_users, &set);
+            }
+        }
+    }
 
     Ok(Json(teams_with_relations))
 }
@@ -116,10 +152,14 @@ pub async fn get_team(
     verify_admin(&pool, &user_pubkey_hex, team_id, tenant_id).await?;
 
     let team_repo = TeamRepository::new(pool.clone());
-    let team_with_relations = team_repo
+    let mut team_with_relations = team_repo
         .find_with_relations(tenant_id, team_id)
         .await
         .map_err(|_| ApiError::not_found("Team not found"))?;
+
+    if let Some(set) = fetch_support_admin_set().await {
+        mark_support_members(&mut team_with_relations.team_users, &set);
+    }
 
     Ok(Json(team_with_relations))
 }
@@ -201,9 +241,13 @@ pub async fn add_user(
         .await?;
 
     // Add the team membership
-    let team_user = team_repo
+    let mut team_user = team_repo
         .add_member(team_id, &new_user_pubkey.to_hex(), request.role.as_str())
         .await?;
+
+    if let Some(set) = fetch_support_admin_set().await {
+        mark_support_members(std::slice::from_mut(&mut team_user), &set);
+    }
 
     Ok(Json(team_user))
 }
@@ -970,5 +1014,82 @@ async fn resolve_display_name(pool: &PgPool, pubkey: &str, tenant_id: i64) -> St
         Some((Some(display_name), _)) if !display_name.is_empty() => display_name,
         Some((_, Some(username))) if !username.is_empty() => username,
         _ => format!("{}…", &pubkey[..8]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::HashSet;
+
+    fn fake_team_user(pubkey: &str, role: TeamUserRole) -> TeamUser {
+        let now = Utc::now();
+        TeamUser {
+            user_pubkey: pubkey.to_string(),
+            team_id: 1,
+            role,
+            email: None,
+            created_at: now,
+            updated_at: now,
+            is_support_member: false,
+        }
+    }
+
+    #[test]
+    fn mark_support_members_flags_only_pubkeys_in_set() {
+        let support = "aaaa".to_string();
+        let owner = "bbbb".to_string();
+        let mut rows = vec![
+            fake_team_user(&support, TeamUserRole::Member),
+            fake_team_user(&owner, TeamUserRole::Admin),
+        ];
+        let set: HashSet<String> = [support.clone()].into_iter().collect();
+
+        mark_support_members(&mut rows, &set);
+
+        assert!(rows[0].is_support_member, "support pubkey must be flagged");
+        assert!(
+            !rows[1].is_support_member,
+            "owner pubkey must NOT be flagged"
+        );
+    }
+
+    #[test]
+    fn mark_support_members_is_idempotent() {
+        let pk = "cccc".to_string();
+        let mut rows = vec![fake_team_user(&pk, TeamUserRole::Member)];
+        let set: HashSet<String> = [pk.clone()].into_iter().collect();
+
+        mark_support_members(&mut rows, &set);
+        mark_support_members(&mut rows, &set);
+
+        assert!(rows[0].is_support_member);
+    }
+
+    #[test]
+    fn mark_support_members_empty_set_is_noop() {
+        let mut rows = vec![fake_team_user("dddd", TeamUserRole::Admin)];
+        let set: HashSet<String> = HashSet::new();
+
+        mark_support_members(&mut rows, &set);
+
+        assert!(!rows[0].is_support_member);
+    }
+
+    #[test]
+    fn mark_support_members_does_not_clear_preexisting_flag() {
+        // If a row was already marked (e.g. enriched upstream), a subsequent
+        // pass with a smaller set must not unset it.
+        let mut rows = vec![fake_team_user("eeee", TeamUserRole::Member)];
+        rows[0].is_support_member = true;
+        let set: HashSet<String> = HashSet::new();
+
+        mark_support_members(&mut rows, &set);
+
+        assert!(
+            rows[0].is_support_member,
+            "preexisting true flag must be preserved"
+        );
     }
 }

--- a/api/src/api/mod.rs
+++ b/api/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod extractors;
 pub mod http;
+pub mod nip98_extractor;
 pub mod tenant;
 pub mod types;

--- a/api/src/api/nip98_extractor.rs
+++ b/api/src/api/nip98_extractor.rs
@@ -1,6 +1,7 @@
 // ABOUTME: NIP-98 service-auth path for admin routes
 // ABOUTME: Verifies Authorization: Nostr <base64> envelopes, resolves admin_role, anti-replay via Redis
 
+use axum::extract::OriginalUri;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 use base64::prelude::*;
@@ -108,12 +109,24 @@ async fn authenticate_nip98(parts: &Parts, auth_header: &str) -> Result<UcanAuth
 /// `X-Forwarded-Host` set by the load balancer (Cloud Run / ALB) so that
 /// HTTPS-signed envelopes verify even though the inbound request to the app
 /// arrives as HTTP.
+///
+/// Reads the path from `OriginalUri` (axum populates it as a request
+/// extension before nesting strips prefixes) so that requests arriving via
+/// `Router::nest("/api", ...)` are reconstructed with the `/api/` prefix
+/// the client actually signed. Falls back to `parts.uri` when no
+/// `OriginalUri` extension is present (e.g. unit tests built from a bare
+/// `Request`).
 fn build_expected_url(parts: &Parts) -> Option<String> {
-    let path_and_query = parts
-        .uri
+    let original_uri = parts
+        .extensions
+        .get::<OriginalUri>()
+        .map(|o| &o.0)
+        .unwrap_or(&parts.uri);
+
+    let path_and_query = original_uri
         .path_and_query()
         .map(|pq| pq.as_str().to_string())
-        .unwrap_or_else(|| parts.uri.path().to_string());
+        .unwrap_or_else(|| original_uri.path().to_string());
 
     let host = parts
         .headers
@@ -260,6 +273,26 @@ mod tests {
             url,
             "https://auth.synvya.com/api/admin/user-lookup?q=alice%40example.com"
         );
+    }
+
+    /// When the request was routed through `Router::nest("/api", ...)`, axum
+    /// strips the `/api` prefix from `parts.uri` but stores the original path
+    /// in the `OriginalUri` extension. The extractor must read from the
+    /// extension so the reconstructed URL matches what the client actually
+    /// signed (including the `/api/` prefix).
+    #[test]
+    fn build_expected_url_uses_original_uri_when_nested() {
+        let mut parts = parts_from(
+            // post-strip path that axum sees inside the nested router
+            "/admin/status",
+            Method::GET,
+            vec![("Host", "auth.synvya.com")],
+        );
+        parts
+            .extensions
+            .insert(OriginalUri("/api/admin/status".parse::<Uri>().unwrap()));
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(url, "https://auth.synvya.com/api/admin/status");
     }
 
     /// Build a NIP-98 Authorization header for the given keys/url/method.

--- a/api/src/api/nip98_extractor.rs
+++ b/api/src/api/nip98_extractor.rs
@@ -1,0 +1,310 @@
+// ABOUTME: NIP-98 service-auth path for admin routes
+// ABOUTME: Verifies Authorization: Nostr <base64> envelopes, resolves admin_role, anti-replay via Redis
+
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use base64::prelude::*;
+use nostr_sdk::{Event, JsonUtil};
+
+use crate::api::extractors::{AuthError, UcanAuth};
+use crate::api::http::admin::{is_full_admin, is_support_admin};
+use crate::nip98;
+
+/// TTL for anti-replay records in Redis. Slightly longer than the 60s
+/// `created_at` tolerance window so the replay record outlives any envelope
+/// that could still be considered fresh.
+const REPLAY_TTL_SECONDS: u64 = 120;
+
+/// Redis key prefix for replay protection records.
+const REPLAY_KEY_PREFIX: &str = "nip98_replay";
+
+/// Try to authenticate via the NIP-98 service-auth path.
+///
+/// Returns:
+/// - `None` if the request does not carry an `Authorization: Nostr ...` header
+///   (caller should fall through to the cookie path).
+/// - `Some(Ok(UcanAuth))` if the envelope verifies and resolves to an
+///   `admin_role` (which may itself be `None` if the pubkey is neither full
+///   nor support admin).
+/// - `Some(Err(AuthError))` if the header is present but verification fails.
+///   The NIP-98 path is exclusive once the header is present — the caller
+///   MUST NOT fall through to the cookie path on this error.
+pub async fn try_authenticate_nip98(parts: &Parts) -> Option<Result<UcanAuth, AuthError>> {
+    let auth_header_str = parts
+        .headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())?;
+
+    if !auth_header_str.starts_with("Nostr ") {
+        return None;
+    }
+
+    Some(authenticate_nip98(parts, auth_header_str).await)
+}
+
+async fn authenticate_nip98(parts: &Parts, auth_header: &str) -> Result<UcanAuth, AuthError> {
+    let path = parts.uri.path().to_string();
+
+    let Some(expected_url) = build_expected_url(parts) else {
+        tracing::warn!(
+            "NIP-98 service-auth: missing Host / X-Forwarded-Host (path: {})",
+            path
+        );
+        return Err(unauthorized());
+    };
+
+    let method = parts.method.as_str();
+
+    let validated =
+        nip98::extract_and_validate(auth_header, &expected_url, method).map_err(|e| {
+            tracing::warn!(
+                "NIP-98 service-auth verification failed (path: {}): {}",
+                path,
+                e
+            );
+            unauthorized()
+        })?;
+
+    let pubkey_hex = validated.pubkey.to_hex();
+
+    let event_id = parse_event_id(auth_header).map_err(|e| {
+        // Should not happen — extract_and_validate already parsed the same bytes.
+        tracing::warn!(
+            "NIP-98 service-auth: failed to parse event id for replay check: {}",
+            e
+        );
+        unauthorized()
+    })?;
+
+    check_replay(&event_id).await?;
+
+    let probe = UcanAuth {
+        pubkey: pubkey_hex.clone(),
+        admin_role: None,
+    };
+    let admin_role = if is_full_admin(&probe) {
+        Some("full".to_string())
+    } else if is_support_admin(&probe).await {
+        Some("support".to_string())
+    } else {
+        None
+    };
+
+    let pubkey_short = pubkey_hex.get(..8).unwrap_or(&pubkey_hex);
+    tracing::debug!(
+        "NIP-98 service-auth: authenticated pubkey={} admin_role={:?} path={}",
+        pubkey_short,
+        admin_role,
+        path
+    );
+
+    Ok(UcanAuth {
+        pubkey: pubkey_hex,
+        admin_role,
+    })
+}
+
+/// Reconstruct the URL the client signed. Trusts `X-Forwarded-Proto` and
+/// `X-Forwarded-Host` set by the load balancer (Cloud Run / ALB) so that
+/// HTTPS-signed envelopes verify even though the inbound request to the app
+/// arrives as HTTP.
+fn build_expected_url(parts: &Parts) -> Option<String> {
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str().to_string())
+        .unwrap_or_else(|| parts.uri.path().to_string());
+
+    let host = parts
+        .headers
+        .get("x-forwarded-host")
+        .or_else(|| parts.headers.get("host"))
+        .and_then(|v| v.to_str().ok())?;
+
+    let proto = parts
+        .headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_else(|| {
+            if host.contains(":443") || !host.contains(':') {
+                "https"
+            } else {
+                "http"
+            }
+        });
+
+    Some(format!("{}://{}{}", proto, host, path_and_query))
+}
+
+/// Parse the event id from a NIP-98 Authorization header.
+fn parse_event_id(auth_header: &str) -> Result<String, String> {
+    let base64_str = auth_header
+        .strip_prefix("Nostr ")
+        .ok_or_else(|| "missing Nostr prefix".to_string())?
+        .trim();
+    let json_bytes = BASE64_STANDARD
+        .decode(base64_str)
+        .map_err(|e| format!("base64: {}", e))?;
+    let event = Event::from_json(&json_bytes).map_err(|e| format!("json: {}", e))?;
+    Ok(event.id.to_hex())
+}
+
+/// Check Redis for envelope replay. Fail-closed on Redis errors — service
+/// auth resolves to full-admin authority for `ALLOWED_PUBKEYS` callers, so
+/// fail-open here would let a captured envelope be reused during an outage.
+async fn check_replay(event_id: &str) -> Result<(), AuthError> {
+    let state = crate::state::get_keycast_state().map_err(|e| {
+        tracing::error!("NIP-98 anti-replay: keycast state unavailable: {:?}", e);
+        service_unavailable()
+    })?;
+
+    let Some(redis) = state.redis.as_ref() else {
+        tracing::error!(
+            "NIP-98 anti-replay: Redis not configured — cannot enforce replay protection"
+        );
+        return Err(service_unavailable());
+    };
+
+    let key = format!("{}:{}", REPLAY_KEY_PREFIX, event_id);
+
+    match redis.set_nx_ex(&key, "1", REPLAY_TTL_SECONDS).await {
+        Ok(true) => Ok(()),
+        Ok(false) => {
+            tracing::warn!(
+                "NIP-98 anti-replay: rejecting replayed envelope id={}",
+                event_id
+            );
+            Err(unauthorized())
+        }
+        Err(e) => {
+            tracing::error!("NIP-98 anti-replay: Redis SET NX failed: {}", e);
+            Err(service_unavailable())
+        }
+    }
+}
+
+fn unauthorized() -> AuthError {
+    AuthError::new(StatusCode::UNAUTHORIZED, "unauthorized".to_string())
+}
+
+fn service_unavailable() -> AuthError {
+    AuthError::new(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "service temporarily unavailable".to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue, Method, Request, Uri};
+    use nostr_sdk::{EventBuilder, Keys, Kind, Tag};
+
+    fn parts_from(uri: &str, method: Method, headers: Vec<(&str, &str)>) -> Parts {
+        let mut req = Request::builder()
+            .method(method)
+            .uri(uri.parse::<Uri>().unwrap())
+            .body(())
+            .unwrap();
+        let hdrs: &mut HeaderMap = req.headers_mut();
+        for (k, v) in headers {
+            hdrs.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        req.into_parts().0
+    }
+
+    #[test]
+    fn build_expected_url_uses_forwarded_proto_and_host() {
+        let parts = parts_from(
+            "/api/admin/support-admins?x=1",
+            Method::POST,
+            vec![
+                ("X-Forwarded-Proto", "https"),
+                ("X-Forwarded-Host", "auth.synvya.com"),
+                ("Host", "internal-host"),
+            ],
+        );
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(url, "https://auth.synvya.com/api/admin/support-admins?x=1");
+    }
+
+    #[test]
+    fn build_expected_url_falls_back_to_host_header() {
+        let parts = parts_from(
+            "/api/admin/support-admins",
+            Method::POST,
+            vec![("Host", "auth.synvya.com")],
+        );
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(url, "https://auth.synvya.com/api/admin/support-admins");
+    }
+
+    #[test]
+    fn build_expected_url_returns_none_without_host() {
+        let parts = parts_from("/api/admin/support-admins", Method::POST, vec![]);
+        assert!(build_expected_url(&parts).is_none());
+    }
+
+    #[test]
+    fn build_expected_url_preserves_query_string() {
+        let parts = parts_from(
+            "/api/admin/user-lookup?q=alice%40example.com",
+            Method::GET,
+            vec![("Host", "auth.synvya.com")],
+        );
+        let url = build_expected_url(&parts).unwrap();
+        assert_eq!(
+            url,
+            "https://auth.synvya.com/api/admin/user-lookup?q=alice%40example.com"
+        );
+    }
+
+    /// Build a NIP-98 Authorization header for the given keys/url/method.
+    async fn make_header(keys: &Keys, url: &str, method: &str) -> String {
+        let event = EventBuilder::new(Kind::HttpAuth, "")
+            .tags([
+                Tag::parse(["u", url]).unwrap(),
+                Tag::parse(["method", method]).unwrap(),
+            ])
+            .sign(keys)
+            .await
+            .unwrap();
+        format!("Nostr {}", BASE64_STANDARD.encode(event.as_json()))
+    }
+
+    #[tokio::test]
+    async fn try_authenticate_returns_none_when_header_absent() {
+        let parts = parts_from(
+            "/api/admin/support-admins",
+            Method::POST,
+            vec![("Host", "auth.synvya.com")],
+        );
+        let result = try_authenticate_nip98(&parts).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn try_authenticate_returns_none_for_bearer_header() {
+        let parts = parts_from(
+            "/api/admin/support-admins",
+            Method::POST,
+            vec![
+                ("Host", "auth.synvya.com"),
+                ("Authorization", "Bearer some-token"),
+            ],
+        );
+        let result = try_authenticate_nip98(&parts).await;
+        assert!(result.is_none(), "Bearer header must fall through");
+    }
+
+    #[tokio::test]
+    async fn parse_event_id_round_trips() {
+        let keys = Keys::generate();
+        let header = make_header(&keys, "https://auth.synvya.com/x", "POST").await;
+        let id = parse_event_id(&header).expect("event id parse");
+        assert_eq!(id.len(), 64, "event id is 32 bytes hex");
+    }
+}

--- a/api/src/redis.rs
+++ b/api/src/redis.rs
@@ -266,6 +266,40 @@ impl PrefixedRedis {
         })
         .await
     }
+
+    /// Atomically `SET key value NX EX ttl_seconds`.
+    ///
+    /// Returns `Ok(true)` if the key was set (it did not previously exist).
+    /// Returns `Ok(false)` if the key already existed (NX condition failed).
+    ///
+    /// Used for anti-replay protection: a unique token is `set_nx_ex`'d on
+    /// first sight; a duplicate within the TTL returns `false`.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if Redis operation fails or connection refresh fails.
+    pub async fn set_nx_ex(&self, key: &str, value: &str, ttl_seconds: u64) -> RedisResult<bool> {
+        let prefixed = self.prefixed_key(key).into_owned();
+        let value = value.to_string();
+        self.with_refresh(|mut conn| {
+            let key = prefixed.clone();
+            let val = value.clone();
+            async move {
+                // SET key value NX EX ttl returns "OK" (bulk string) if set,
+                // or nil if NX failed. Map to bool.
+                let result: Option<String> = redis::cmd("SET")
+                    .arg(key)
+                    .arg(val)
+                    .arg("NX")
+                    .arg("EX")
+                    .arg(ttl_seconds)
+                    .query_async(&mut conn)
+                    .await?;
+                Ok(result.is_some())
+            }
+        })
+        .await
+    }
 }
 
 #[cfg(test)]

--- a/api/tests/admin_support_access_test.rs
+++ b/api/tests/admin_support_access_test.rs
@@ -1,0 +1,311 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for the AuthorizationRepository::find_active_support_for_caller
+// ABOUTME: helper that backs DELETE /api/admin/teams/:id/support-access (label-prefix filter,
+// ABOUTME: tenant scoping, team scoping, exclusion of revoked rows).
+
+use keycast_core::custom_permissions::allowed_kinds::AllowedKindsConfig;
+use keycast_core::repositories::{AuthorizationRepository, TeamRepository};
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+
+const TENANT_A: i64 = 1;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+/// Ensure a tenant row exists. The default tenant_id=1 is created by initial
+/// migrations; second tenant is inserted lazily for the cross-tenant test.
+async fn ensure_tenant(pool: &PgPool, tenant_id: i64) {
+    let _ = sqlx::query(
+        "INSERT INTO tenants (id, name, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(tenant_id)
+    .bind(format!("test-tenant-{}", tenant_id))
+    .execute(pool)
+    .await;
+}
+
+/// Ensure a user row exists for a pubkey on a given tenant.
+async fn ensure_user(pool: &PgPool, tenant_id: i64, pubkey: &str) {
+    let _ = sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (pubkey, tenant_id) DO NOTHING",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .execute(pool)
+    .await;
+}
+
+struct Fixture {
+    team_id: i32,
+    stored_key_id: i32,
+    policy_id: i32,
+}
+
+/// Provision a team with a stored key and an "All Access" policy, returning ids.
+/// Each test gets a fresh team with a unique name to avoid cross-test pollution.
+async fn provision_team(pool: &PgPool, tenant_id: i64, admin_pubkey: &str) -> Fixture {
+    ensure_tenant(pool, tenant_id).await;
+    ensure_user(pool, tenant_id, admin_pubkey).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let allowed_kinds_config = serde_json::to_value(AllowedKindsConfig::default()).unwrap();
+    let team_name = format!("Test Team {}", Uuid::new_v4());
+
+    let team_with_relations = team_repo
+        .create_with_admin(tenant_id, &team_name, admin_pubkey, allowed_kinds_config)
+        .await
+        .expect("create_with_admin should succeed");
+
+    let team_id = team_with_relations.team.id;
+    let policy_id = team_with_relations.policies[0].policy.id;
+
+    // Insert a stored key directly. StoredKeyRepository::create requires a
+    // fully-encrypted secret; for label-filter tests a placeholder secret_key
+    // blob is sufficient.
+    let pubkey_hex = Keys::generate().public_key().to_hex();
+    let stored_key_id: i32 = sqlx::query_scalar(
+        "INSERT INTO stored_keys (tenant_id, team_id, name, pubkey, secret_key, created_at, updated_at)
+         VALUES ($1, $2, 'test-key', $3, $4::bytea, NOW(), NOW())
+         RETURNING id",
+    )
+    .bind(tenant_id)
+    .bind(team_id)
+    .bind(&pubkey_hex)
+    .bind(b"placeholder-encrypted-key".as_ref())
+    .fetch_one(pool)
+    .await
+    .expect("stored_key insert should succeed");
+
+    Fixture {
+        team_id,
+        stored_key_id,
+        policy_id,
+    }
+}
+
+async fn insert_authorization(
+    repo: &AuthorizationRepository,
+    tenant_id: i64,
+    fixture: &Fixture,
+    label: Option<&str>,
+) -> i32 {
+    let bunker_pubkey = Keys::generate().public_key().to_hex();
+    let relays = serde_json::json!(Vec::<String>::new());
+    let auth = repo
+        .create(
+            tenant_id,
+            fixture.stored_key_id,
+            fixture.policy_id,
+            "test-secret-hash",
+            &bunker_pubkey,
+            &relays,
+            None,
+            None,
+            label,
+        )
+        .await
+        .expect("auth insert should succeed");
+    auth.id
+}
+
+async fn cleanup_team(pool: &PgPool, tenant_id: i64, team_id: i32) {
+    // Cascade-friendly cleanup in dependency order.
+    let _ = sqlx::query(
+        "DELETE FROM authorizations WHERE stored_key_id IN
+            (SELECT id FROM stored_keys WHERE team_id = $1 AND tenant_id = $2)",
+    )
+    .bind(team_id)
+    .bind(tenant_id)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM stored_keys WHERE team_id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM policy_permissions WHERE policy_id IN (SELECT id FROM policies WHERE team_id = $1)")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM policies WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM team_users WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM teams WHERE id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_returns_only_caller_label() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+    let other_support = Keys::generate().public_key().to_hex();
+
+    let fx = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    // Caller's own support-labeled auth — should match.
+    let mine =
+        insert_authorization(&repo, TENANT_A, &fx, Some(&format!("support:{}", support))).await;
+
+    // A different support admin's auth on the same team — should NOT match.
+    let other = insert_authorization(
+        &repo,
+        TENANT_A,
+        &fx,
+        Some(&format!("support:{}", other_support)),
+    )
+    .await;
+
+    // An owner-minted auth with no support label — should NOT match.
+    let owner_auth = insert_authorization(&repo, TENANT_A, &fx, Some("server-bunker")).await;
+
+    // A null-label auth — should NOT match.
+    let null_label_auth = insert_authorization(&repo, TENANT_A, &fx, None).await;
+
+    let found = repo
+        .find_active_support_for_caller(TENANT_A, fx.team_id, &support)
+        .await
+        .expect("query should succeed");
+
+    let ids: Vec<i32> = found.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&mine), "caller's own auth must be returned");
+    assert!(
+        !ids.contains(&other),
+        "another support admin's auth must NOT be returned"
+    );
+    assert!(
+        !ids.contains(&owner_auth),
+        "owner-minted auth must NOT be returned"
+    );
+    assert!(
+        !ids.contains(&null_label_auth),
+        "null-label auth must NOT be returned"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx.team_id).await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_excludes_revoked() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+
+    let fx = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    let label = format!("support:{}", support);
+    let live = insert_authorization(&repo, TENANT_A, &fx, Some(&label)).await;
+    let to_revoke = insert_authorization(&repo, TENANT_A, &fx, Some(&label)).await;
+
+    repo.revoke(TENANT_A, to_revoke, Some("test"))
+        .await
+        .expect("revoke should succeed");
+
+    let found = repo
+        .find_active_support_for_caller(TENANT_A, fx.team_id, &support)
+        .await
+        .expect("query should succeed");
+
+    let ids: Vec<i32> = found.iter().map(|(id, _)| *id).collect();
+    assert!(ids.contains(&live), "live auth must be returned");
+    assert!(
+        !ids.contains(&to_revoke),
+        "revoked auth must NOT be returned"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx.team_id).await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_is_team_scoped() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+
+    let fx_a = provision_team(&pool, TENANT_A, &admin).await;
+    let fx_b = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    let label = format!("support:{}", support);
+    let on_a = insert_authorization(&repo, TENANT_A, &fx_a, Some(&label)).await;
+    let on_b = insert_authorization(&repo, TENANT_A, &fx_b, Some(&label)).await;
+
+    let found_a = repo
+        .find_active_support_for_caller(TENANT_A, fx_a.team_id, &support)
+        .await
+        .expect("query should succeed");
+    let ids_a: Vec<i32> = found_a.iter().map(|(id, _)| *id).collect();
+    assert!(ids_a.contains(&on_a));
+    assert!(
+        !ids_a.contains(&on_b),
+        "team B auth must not appear for team A query"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx_a.team_id).await;
+    cleanup_team(&pool, TENANT_A, fx_b.team_id).await;
+}
+
+#[tokio::test]
+async fn test_find_active_support_label_suffix_matches() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let support = Keys::generate().public_key().to_hex();
+
+    let fx = provision_team(&pool, TENANT_A, &admin).await;
+    let repo = AuthorizationRepository::new(pool.clone());
+
+    // Grant endpoint stamps `support:{caller} (suffix)` when a label suffix is
+    // supplied; the LIKE filter must match the prefix variant.
+    let with_suffix = insert_authorization(
+        &repo,
+        TENANT_A,
+        &fx,
+        Some(&format!("support:{} (manual debug)", support)),
+    )
+    .await;
+
+    let found = repo
+        .find_active_support_for_caller(TENANT_A, fx.team_id, &support)
+        .await
+        .expect("query should succeed");
+
+    let ids: Vec<i32> = found.iter().map(|(id, _)| *id).collect();
+    assert!(
+        ids.contains(&with_suffix),
+        "labels with a suffix must still match the prefix filter"
+    );
+
+    cleanup_team(&pool, TENANT_A, fx.team_id).await;
+}

--- a/api/tests/admin_team_lookup_test.rs
+++ b/api/tests/admin_team_lookup_test.rs
@@ -1,0 +1,315 @@
+#![cfg(feature = "integration-tests")]
+
+// ABOUTME: Integration tests for TeamRepository::search_by_name, the helper
+// ABOUTME: behind GET /api/admin/team-lookup. Covers case-insensitive substring
+// ABOUTME: matching, tenant scoping, admin email aggregation, has_stored_key
+// ABOUTME: flag, and the result limit.
+
+use keycast_core::custom_permissions::allowed_kinds::AllowedKindsConfig;
+use keycast_core::repositories::TeamRepository;
+use nostr_sdk::Keys;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+mod common;
+
+const TENANT_A: i64 = 1;
+
+async fn setup_pool() -> PgPool {
+    common::assert_test_database_url();
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost/keycast_test".to_string());
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    sqlx::migrate!("../database/migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    pool
+}
+
+async fn ensure_tenant(pool: &PgPool, tenant_id: i64) {
+    let _ = sqlx::query(
+        "INSERT INTO tenants (id, name, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .bind(tenant_id)
+    .bind(format!("test-tenant-{}", tenant_id))
+    .execute(pool)
+    .await;
+}
+
+/// Create a user with optional email. Idempotent on (pubkey, tenant_id).
+async fn ensure_user_with_email(pool: &PgPool, tenant_id: i64, pubkey: &str, email: Option<&str>) {
+    let _ = sqlx::query(
+        "INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())
+         ON CONFLICT (pubkey, tenant_id) DO UPDATE SET email = EXCLUDED.email",
+    )
+    .bind(pubkey)
+    .bind(tenant_id)
+    .bind(email)
+    .execute(pool)
+    .await;
+}
+
+/// Create a team with the given admin and (optionally) a stored key. Returns team_id.
+async fn create_team(
+    pool: &PgPool,
+    tenant_id: i64,
+    name: &str,
+    admin_pubkey: &str,
+    with_stored_key: bool,
+) -> i32 {
+    ensure_tenant(pool, tenant_id).await;
+    ensure_user_with_email(pool, tenant_id, admin_pubkey, None).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let allowed_kinds_config = serde_json::to_value(AllowedKindsConfig::default()).unwrap();
+    let twr = team_repo
+        .create_with_admin(tenant_id, name, admin_pubkey, allowed_kinds_config)
+        .await
+        .expect("create_with_admin should succeed");
+
+    if with_stored_key {
+        let pubkey_hex = Keys::generate().public_key().to_hex();
+        sqlx::query(
+            "INSERT INTO stored_keys (tenant_id, team_id, name, pubkey, secret_key, created_at, updated_at)
+             VALUES ($1, $2, 'test-key', $3, $4::bytea, NOW(), NOW())",
+        )
+        .bind(tenant_id)
+        .bind(twr.team.id)
+        .bind(&pubkey_hex)
+        .bind(b"placeholder-encrypted-key".as_ref())
+        .execute(pool)
+        .await
+        .expect("stored_key insert should succeed");
+    }
+
+    twr.team.id
+}
+
+async fn cleanup_team(pool: &PgPool, tenant_id: i64, team_id: i32) {
+    let _ = sqlx::query("DELETE FROM stored_keys WHERE team_id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "DELETE FROM policy_permissions WHERE policy_id IN (SELECT id FROM policies WHERE team_id = $1)",
+    )
+    .bind(team_id)
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM policies WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM team_users WHERE team_id = $1")
+        .bind(team_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM teams WHERE id = $1 AND tenant_id = $2")
+        .bind(team_id)
+        .bind(tenant_id)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_search_matches_substring_case_insensitive() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let target_name = format!("Joes Diner {}", unique);
+    let unrelated_name = format!("Bella Bistro {}", unique);
+
+    let target = create_team(&pool, TENANT_A, &target_name, &admin, true).await;
+    let unrelated = create_team(&pool, TENANT_A, &unrelated_name, &admin, true).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let results = team_repo
+        .search_by_name(TENANT_A, &format!("joes {}", &unique[..8]), 25)
+        .await
+        .expect("search should succeed");
+
+    let ids: Vec<i32> = results.iter().map(|r| r.id).collect();
+    assert!(ids.contains(&target), "target team must be in results");
+    assert!(
+        !ids.contains(&unrelated),
+        "unrelated team must NOT be in results"
+    );
+
+    cleanup_team(&pool, TENANT_A, target).await;
+    cleanup_team(&pool, TENANT_A, unrelated).await;
+}
+
+#[tokio::test]
+async fn test_search_aggregates_admin_emails() {
+    let pool = setup_pool().await;
+    let admin1 = Keys::generate().public_key().to_hex();
+    let admin2 = Keys::generate().public_key().to_hex();
+    let member = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let team_name = format!("Multi Admin {}", unique);
+
+    ensure_tenant(&pool, TENANT_A).await;
+    ensure_user_with_email(&pool, TENANT_A, &admin1, Some("admin1@example.com")).await;
+    ensure_user_with_email(&pool, TENANT_A, &admin2, Some("admin2@example.com")).await;
+    ensure_user_with_email(&pool, TENANT_A, &member, Some("member@example.com")).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let allowed_kinds_config = serde_json::to_value(AllowedKindsConfig::default()).unwrap();
+    let twr = team_repo
+        .create_with_admin(TENANT_A, &team_name, &admin1, allowed_kinds_config)
+        .await
+        .expect("create");
+    let team_id = twr.team.id;
+
+    team_repo
+        .add_member(team_id, &admin2, "admin")
+        .await
+        .expect("add second admin");
+    team_repo
+        .add_member(team_id, &member, "member")
+        .await
+        .expect("add member");
+
+    let results = team_repo
+        .search_by_name(TENANT_A, &unique, 25)
+        .await
+        .expect("search");
+    let row = results.iter().find(|r| r.id == team_id).expect("hit");
+
+    let mut emails = row.admin_emails.clone();
+    emails.sort();
+    assert_eq!(
+        emails,
+        vec![
+            "admin1@example.com".to_string(),
+            "admin2@example.com".to_string()
+        ],
+        "admin emails must include both admins, deduped, and exclude the member"
+    );
+
+    cleanup_team(&pool, TENANT_A, team_id).await;
+}
+
+#[tokio::test]
+async fn test_search_has_stored_key_flag() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+
+    let with_key = create_team(
+        &pool,
+        TENANT_A,
+        &format!("WithKey {}", unique),
+        &admin,
+        true,
+    )
+    .await;
+    let without_key =
+        create_team(&pool, TENANT_A, &format!("NoKey {}", unique), &admin, false).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let results = team_repo
+        .search_by_name(TENANT_A, &unique, 25)
+        .await
+        .expect("search");
+
+    let with = results.iter().find(|r| r.id == with_key).expect("with");
+    let without = results
+        .iter()
+        .find(|r| r.id == without_key)
+        .expect("without");
+
+    assert!(with.has_stored_key, "team with stored key must flag true");
+    assert!(
+        !without.has_stored_key,
+        "team without stored key must flag false"
+    );
+
+    cleanup_team(&pool, TENANT_A, with_key).await;
+    cleanup_team(&pool, TENANT_A, without_key).await;
+}
+
+#[tokio::test]
+async fn test_search_is_tenant_scoped() {
+    let pool = setup_pool().await;
+    const TENANT_B: i64 = 999_001;
+    let admin_a = Keys::generate().public_key().to_hex();
+    let admin_b = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let shared_name = format!("Cross Tenant {}", unique);
+
+    let team_a = create_team(&pool, TENANT_A, &shared_name, &admin_a, true).await;
+    let team_b = create_team(&pool, TENANT_B, &shared_name, &admin_b, true).await;
+
+    let team_repo = TeamRepository::new(pool.clone());
+
+    let results_a = team_repo
+        .search_by_name(TENANT_A, &unique, 25)
+        .await
+        .expect("search A");
+    let ids_a: Vec<i32> = results_a.iter().map(|r| r.id).collect();
+    assert!(ids_a.contains(&team_a));
+    assert!(
+        !ids_a.contains(&team_b),
+        "tenant B's team must not leak to tenant A"
+    );
+
+    let results_b = team_repo
+        .search_by_name(TENANT_B, &unique, 25)
+        .await
+        .expect("search B");
+    let ids_b: Vec<i32> = results_b.iter().map(|r| r.id).collect();
+    assert!(ids_b.contains(&team_b));
+    assert!(
+        !ids_b.contains(&team_a),
+        "tenant A's team must not leak to tenant B"
+    );
+
+    cleanup_team(&pool, TENANT_A, team_a).await;
+    cleanup_team(&pool, TENANT_B, team_b).await;
+    let _ = sqlx::query("DELETE FROM tenants WHERE id = $1")
+        .bind(TENANT_B)
+        .execute(&pool)
+        .await;
+}
+
+#[tokio::test]
+async fn test_search_respects_limit() {
+    let pool = setup_pool().await;
+    let admin = Keys::generate().public_key().to_hex();
+    let unique = Uuid::new_v4().to_string();
+    let mut team_ids = Vec::new();
+
+    for i in 0..5 {
+        let id = create_team(
+            &pool,
+            TENANT_A,
+            &format!("LimitTest {} {}", unique, i),
+            &admin,
+            false,
+        )
+        .await;
+        team_ids.push(id);
+    }
+
+    let team_repo = TeamRepository::new(pool.clone());
+    let results = team_repo
+        .search_by_name(TENANT_A, &unique, 3)
+        .await
+        .expect("search");
+
+    assert_eq!(results.len(), 3, "limit must be respected");
+
+    for id in team_ids {
+        cleanup_team(&pool, TENANT_A, id).await;
+    }
+}

--- a/api/tests/admin_team_lookup_test.rs
+++ b/api/tests/admin_team_lookup_test.rs
@@ -32,29 +32,36 @@ async fn setup_pool() -> PgPool {
 }
 
 async fn ensure_tenant(pool: &PgPool, tenant_id: i64) {
-    let _ = sqlx::query(
-        "INSERT INTO tenants (id, name, created_at, updated_at)
-         VALUES ($1, $2, NOW(), NOW())
+    // The tenants table requires (id, domain, name) — domain is NOT NULL.
+    sqlx::query(
+        "INSERT INTO tenants (id, domain, name, created_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())
          ON CONFLICT (id) DO NOTHING",
     )
     .bind(tenant_id)
+    .bind(format!("test-tenant-{}.example.test", tenant_id))
     .bind(format!("test-tenant-{}", tenant_id))
     .execute(pool)
-    .await;
+    .await
+    .expect("ensure_tenant insert must succeed");
 }
 
-/// Create a user with optional email. Idempotent on (pubkey, tenant_id).
+/// Create or update a user with optional email. The unique index on `users`
+/// is on `pubkey` alone (`users_pubkey_idx`), not `(pubkey, tenant_id)`.
 async fn ensure_user_with_email(pool: &PgPool, tenant_id: i64, pubkey: &str, email: Option<&str>) {
-    let _ = sqlx::query(
+    sqlx::query(
         "INSERT INTO users (pubkey, tenant_id, email, created_at, updated_at)
          VALUES ($1, $2, $3, NOW(), NOW())
-         ON CONFLICT (pubkey, tenant_id) DO UPDATE SET email = EXCLUDED.email",
+         ON CONFLICT (pubkey) DO UPDATE
+             SET email = EXCLUDED.email,
+                 tenant_id = EXCLUDED.tenant_id",
     )
     .bind(pubkey)
     .bind(tenant_id)
     .bind(email)
     .execute(pool)
-    .await;
+    .await
+    .expect("ensure_user_with_email insert must succeed");
 }
 
 /// Create a team with the given admin and (optionally) a stored key. Returns team_id.
@@ -125,15 +132,19 @@ async fn test_search_matches_substring_case_insensitive() {
     let pool = setup_pool().await;
     let admin = Keys::generate().public_key().to_hex();
     let unique = Uuid::new_v4().to_string();
-    let target_name = format!("Joes Diner {}", unique);
-    let unrelated_name = format!("Bella Bistro {}", unique);
+    // Two teams; target name carries an uppercase prefix so we can verify the
+    // case-insensitive match. The disambiguating substring lives at the start.
+    let target_name = format!("JoesDiner-{}", unique);
+    let unrelated_name = format!("BellaBistro-{}", unique);
 
     let target = create_team(&pool, TENANT_A, &target_name, &admin, true).await;
     let unrelated = create_team(&pool, TENANT_A, &unrelated_name, &admin, true).await;
 
     let team_repo = TeamRepository::new(pool.clone());
+    // Lowercase substring of the target name. Must match `JoesDiner-…`
+    // case-insensitively and must NOT match `BellaBistro-…`.
     let results = team_repo
-        .search_by_name(TENANT_A, &format!("joes {}", &unique[..8]), 25)
+        .search_by_name(TENANT_A, &format!("joesdiner-{}", &unique[..8]), 25)
         .await
         .expect("search should succeed");
 

--- a/build.README.md
+++ b/build.README.md
@@ -95,8 +95,8 @@ docker compose ps
 The `keycast-unified` container should show a status of `Up (healthy)`.
 
 ### Access the Web UI
-- **Docker Mode**: The API is on **[http://localhost:3000](http://localhost:3000)** and the Dashboard is on **[http://localhost:5172](http://localhost:5172)**.
-- **Native Dev Mode**: The API is on port 3000, and the live-reloading frontend is on **[http://localhost:5173](http://localhost:5173)**.
+- **Docker Mode**: The Rust binary serves **both the API and the SvelteKit dashboard** on a single port — open **[http://localhost:3000](http://localhost:3000)** for both. (The web app is built with `adapter-static` in [web/svelte.config.js](web/svelte.config.js) and the unified runtime serves the static bundle from `WEB_BUILD_DIR=/app/web` alongside the `/api/*` routes. The `5172:5173` mapping in `docker-compose.yml` is a leftover from the pre-`adapter-static` era and serves nothing — slated for cleanup.)
+- **Native Dev Mode**: The Rust API is on port 3000 (`bun run dev`), and the Vite live-reloading frontend is on **[http://localhost:5173](http://localhost:5173)** (`bun run dev:web`). The two are separate processes in this mode.
 
 ---
 

--- a/core/src/repositories/authorization.rs
+++ b/core/src/repositories/authorization.rs
@@ -105,6 +105,35 @@ impl AuthorizationRepository {
         .map_err(Into::into)
     }
 
+    /// Find a support admin's own active authorizations on a team, identified
+    /// by the `support:{caller_pubkey_hex}` label prefix stamped at grant time.
+    ///
+    /// Returns `(authorization_id, bunker_public_key)` pairs. Used by the
+    /// `DELETE /admin/teams/:id/support-access` endpoint to bulk-revoke.
+    pub async fn find_active_support_for_caller(
+        &self,
+        tenant_id: i64,
+        team_id: i32,
+        caller_pubkey_hex: &str,
+    ) -> Result<Vec<(i32, String)>, RepositoryError> {
+        let label_prefix = format!("support:{}", caller_pubkey_hex);
+        sqlx::query_as::<_, (i32, String)>(
+            "SELECT a.id, a.bunker_public_key
+             FROM authorizations a
+             JOIN stored_keys sk ON sk.id = a.stored_key_id
+             WHERE a.tenant_id = $1
+               AND sk.team_id = $2
+               AND a.revoked_at IS NULL
+               AND a.label LIKE $3 || '%'",
+        )
+        .bind(tenant_id)
+        .bind(team_id)
+        .bind(label_prefix)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
     /// Soft-delete an authorization by setting `revoked_at = NOW()`.
     /// Returns the bunker_public_key of the revoked row (used by the caller to
     /// notify the signer daemon via the authorization channel), or `None` if

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -32,6 +32,6 @@ pub use policy::PolicyRepository;
 pub use refresh_token::RefreshTokenRepository;
 pub use registered_client::RegisteredClientRepository;
 pub use stored_key::StoredKeyRepository;
-pub use team::TeamRepository;
+pub use team::{TeamRepository, TeamSearchResult};
 pub use team_invitation::TeamInvitationRepository;
 pub use user::{AdminUserDetails, DeleteAccountResult, UserRepository, VerificationTokenData};

--- a/core/src/repositories/team.rs
+++ b/core/src/repositories/team.rs
@@ -6,7 +6,24 @@ use crate::types::policy::{Policy, PolicyWithPermissions};
 use crate::types::stored_key::{PublicStoredKey, StoredKey};
 use crate::types::team::{Team, TeamWithRelations};
 use crate::types::user::TeamUser;
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 use sqlx::PgPool;
+
+/// Result row for the team-name search used by `GET /api/admin/team-lookup`.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct TeamSearchResult {
+    pub id: i32,
+    pub name: String,
+    pub created_at: DateTime<chrono::Utc>,
+    /// Emails of admins on the team (deduped). Empty when no admin has an
+    /// email on file. Used to disambiguate when multiple teams share a name.
+    pub admin_emails: Vec<String>,
+    /// `true` when the team has at least one row in `stored_keys`. A team
+    /// without a stored key is not eligible for `/support-access`.
+    pub has_stored_key: bool,
+}
 
 /// Repository for team-related database operations.
 #[derive(Debug, Clone)]
@@ -28,6 +45,51 @@ impl TeamRepository {
         .bind(tenant_id)
         .bind(team_id)
         .fetch_one(&self.pool)
+        .await
+        .map_err(Into::into)
+    }
+
+    /// Search teams by name within a tenant. Returns up to `limit` rows whose
+    /// names match the case-insensitive substring `query`. Each row carries
+    /// the team's admin emails (for disambiguation when multiple teams share
+    /// a name) and a flag indicating whether the team has a stored key
+    /// (a team with no stored key is not eligible for `/support-access`).
+    ///
+    /// Used by `GET /api/admin/team-lookup`.
+    pub async fn search_by_name(
+        &self,
+        tenant_id: i64,
+        query: &str,
+        limit: i64,
+    ) -> Result<Vec<TeamSearchResult>, RepositoryError> {
+        let pattern = format!("%{}%", query);
+        sqlx::query_as::<_, TeamSearchResult>(
+            "SELECT
+                t.id,
+                t.name,
+                t.created_at,
+                COALESCE(
+                    ARRAY_AGG(DISTINCT u.email)
+                        FILTER (WHERE u.email IS NOT NULL AND tu.role = 'admin'),
+                    '{}'
+                )::text[] AS admin_emails,
+                EXISTS (
+                    SELECT 1 FROM stored_keys sk
+                    WHERE sk.team_id = t.id AND sk.tenant_id = $1
+                ) AS has_stored_key
+             FROM teams t
+             LEFT JOIN team_users tu ON tu.team_id = t.id
+             LEFT JOIN users u ON u.pubkey = tu.user_pubkey AND u.tenant_id = $1
+             WHERE t.tenant_id = $1
+               AND t.name ILIKE $2
+             GROUP BY t.id, t.name, t.created_at
+             ORDER BY t.name
+             LIMIT $3",
+        )
+        .bind(tenant_id)
+        .bind(pattern)
+        .bind(limit)
+        .fetch_all(&self.pool)
         .await
         .map_err(Into::into)
     }

--- a/core/src/types/user.rs
+++ b/core/src/types/user.rs
@@ -53,6 +53,13 @@ pub struct TeamUser {
     pub created_at: DateTime<chrono::Utc>,
     /// The date and time the user was last updated
     pub updated_at: DateTime<chrono::Utc>,
+    /// True if `user_pubkey` is currently in the Redis `support_admins` set.
+    /// Populated by API handlers after fetching from the repository; default
+    /// `false` when no enrichment has been done (e.g., daemon code paths,
+    /// Redis unavailable). Not stored in the database.
+    #[serde(default)]
+    #[sqlx(default)]
+    pub is_support_member: bool,
 }
 
 /// The role of a user in a team

--- a/docker-compose.synvya.yml
+++ b/docker-compose.synvya.yml
@@ -77,6 +77,10 @@ services:
       # Synvya hosts the password reset page on a different domain
       # (account.synvya.com / account.staging.synvya.com) from the auth host.
       PASSWORD_RESET_BASE_URL: ${PASSWORD_RESET_BASE_URL:?error}
+      # Synvya Admin lives on a separate host. The post-claim success page
+      # in the keycast claim flow links to this URL so newly-onboarded
+      # admins land directly on admin.synvya.com (or staging equivalent).
+      ADMIN_BASE_URL: ${ADMIN_BASE_URL:?error}
       DISABLE_EMAILS:
       # Frontend
       VITE_DOMAIN: ${VITE_DOMAIN:-}

--- a/docs/synvya/admin-user-provisioning.md
+++ b/docs/synvya/admin-user-provisioning.md
@@ -1,0 +1,78 @@
+# Admin User Provisioning
+
+Keycast-vantage-point reference for the cross-repo "admin user provisioning" feature. **No Keycast code changes are required for this feature.** This file documents which existing Keycast endpoints are consumed by the Synvya server during admin onboarding, so future Keycast maintainers don't inadvertently break a downstream contract.
+
+The same feature has parallel specs in the other repos:
+
+- [Cross-system `admin-user-provisioning.md`](https://github.com/Synvya/docs/blob/main/architecture/admin-user-provisioning.md) — system-wide design and the two-path UX.
+- [Server `admin-user-provisioning.md`](https://github.com/Synvya/server/blob/staging/docs/specs/admin-user-provisioning.md) — TypeScript implementation.
+- [Systemtools `admin-user-provisioning.md`](https://github.com/Synvya/systemtools/blob/staging/docs/specs/admin-user-provisioning.md) — UI: segmented "Add Admin" control.
+
+**System context** (Keycast):
+
+- [Keycast Service Auth](keycast-service-auth.md) — foundation; admin provisioning calls go over this NIP-98 service auth path.
+- [Architecture Context](architecture-context.md)
+- [Support Users](support-users.md) — sister consumer of the same foundation.
+
+---
+
+## 1. Endpoints Consumed
+
+The Synvya server, signing each call with `SERVER_BUNKER_CLIENT_PRIVATE_KEY` per the [Keycast Service Auth](keycast-service-auth.md) foundation, calls these existing Keycast endpoints during admin provisioning:
+
+| Endpoint | File | Purpose in this flow |
+|---|---|---|
+| `GET /api/admin/user-lookup?q=<email>` | [`api/src/api/http/admin.rs:844`](../../api/src/api/http/admin.rs) | Detect if a Keycast account already exists for the recipient's email. If yes, skip preload + claim. |
+| `POST /api/admin/preload-user` | [`api/src/api/http/admin.rs:208`](../../api/src/api/http/admin.rs) | Generate a fresh Keycast account; Keycast generates the keypair, encrypts the nsec, returns the pubkey. |
+| `POST /api/admin/claim-tokens` | [`api/src/api/http/admin.rs:501`](../../api/src/api/http/admin.rs) | Generate a one-time claim URL bound to the preloaded account. |
+| `GET /api/claim?token=...` | [`api/src/api/http/claim.rs:42`](../../api/src/api/http/claim.rs) | Server-rendered HTML form where the recipient sets email + password. Public route, token-gated. |
+
+The first three are gated by `is_full_admin`. The Synvya server pubkey is recognized as full admin via `ALLOWED_PUBKEYS` per the foundation spec.
+
+The fourth, `/api/claim`, is server-rendered HTML in Rust — **not** part of the SvelteKit web UI. It remains accessible when `DISABLE_WEB_UI=true` because the no-web-UI guard whitelists `/api/*`.
+
+## 2. Vine-Flavored Field Repurposing
+
+`POST /api/admin/preload-user` requires `vine_id` and `username`. These are Vine-import vocabulary; admin provisioning has no Vine semantics. The Synvya server synthesizes both:
+
+- `vine_id`: `"synvya-admin-${uuid}"` — guaranteed unique per call. Internally Keycast uses this as the lookup key for the claim flow.
+- `username`: derived from email local-part, with numeric suffix on conflict.
+
+This is a small semantic wart — a non-Vine flow flowing through Vine-named fields. It is acknowledged and accepted; **no Keycast change is requested as part of this spec**. A future cleanup PR could rename the field (e.g. `preload_id`) with a backwards-compatible alias, but it is not blocking.
+
+## 3. What Must Not Break
+
+If you are refactoring or simplifying these endpoints, please preserve:
+
+- The `vine_id` field on `preload-user` (or provide an alias). The Synvya server keys its preload + claim sequence on whatever value is sent in this field.
+- The `delivery_email` field semantics in `claim-tokens` (Synvya server may opt to use Keycast's email delivery instead of its own; see § 5 below).
+- The `email_verified = true` outcome of a successful claim. Synvya admins must be able to log in immediately after claiming, without an additional verify-email round-trip.
+- The server-rendered `/api/claim` HTML page surviving with `DISABLE_WEB_UI=true`. Synvya production has no SvelteKit UI; the claim form is the recipient's only path to set a password.
+
+## 4. Side Effects on Keycast
+
+Once admin provisioning ships, expect a steady-state pattern of:
+
+- One `preload-user` + one `claim-tokens` call per Synvya admin onboard (Path B; "by email").
+- Claim activity on `/api/claim` for those users.
+- New `users` and `personal_keys` rows for each claimed admin (same as any other Keycast registration).
+
+Volume is low (a handful of admin onboards per quarter at current Synvya scale).
+
+## 5. Email Delivery: Synvya-Side, Not Keycast
+
+The Synvya server sends the invitation email itself, using its existing email infrastructure (the same path that sends team invitations and password resets). The recipient's email comes **from a Synvya domain**, not from Keycast.
+
+The body contains the claim URL (which points at Keycast). The "From" header is Synvya. This keeps branding consistent and avoids Keycast email infra dependencies for this flow.
+
+The Synvya server therefore does **not** use the `delivery_email` field on `claim-tokens` for the admin-provisioning flow. (It may use it for other flows; preserve the field's behavior regardless.)
+
+## 6. Open Item
+
+- **Pre-claim demotion / removal.** If a systemtools superadmin removes an admin row before the recipient has claimed their Keycast account, the preloaded account in Keycast is orphaned (still exists, never claimed). Cleanup is out of scope for v1; existing claim-token TTL eventually expires the dangling token, but the user/personal_keys row persists. A future cleanup pass could revoke unclaimed preloaded accounts created by the systemtools service identity. Track if it becomes a real problem.
+
+## 7. Cross-References
+
+- For the systemtools UX, see [Systemtools spec](https://github.com/Synvya/systemtools/blob/staging/docs/specs/admin-user-provisioning.md).
+- For the server orchestration, see [Server spec](https://github.com/Synvya/server/blob/staging/docs/specs/admin-user-provisioning.md).
+- For the system-wide rationale and the two-path UX, see [System spec](https://github.com/Synvya/docs/blob/main/architecture/admin-user-provisioning.md).

--- a/docs/synvya/admin-user-provisioning.md
+++ b/docs/synvya/admin-user-provisioning.md
@@ -24,12 +24,14 @@ The Synvya server, signing each call with `SERVER_BUNKER_CLIENT_PRIVATE_KEY` per
 |---|---|---|
 | `GET /api/admin/user-lookup?q=<email>` | [`api/src/api/http/admin.rs:844`](../../api/src/api/http/admin.rs) | Detect if a Keycast account already exists for the recipient's email. If yes, skip preload + claim. |
 | `POST /api/admin/preload-user` | [`api/src/api/http/admin.rs:208`](../../api/src/api/http/admin.rs) | Generate a fresh Keycast account; Keycast generates the keypair, encrypts the nsec, returns the pubkey. |
-| `POST /api/admin/claim-tokens` | [`api/src/api/http/admin.rs:501`](../../api/src/api/http/admin.rs) | Generate a one-time claim URL bound to the preloaded account. |
+| `POST /api/admin/claim-tokens/batch` | [`api/src/api/http/admin.rs:590`](../../api/src/api/http/admin.rs) | Called with a single-item `vine_ids` array and `delivery_email` set to the new admin's address. Generates the claim token **and sends the claim email via Keycast's existing `send_claim_email` path** (SES, `synvya.com` domain). |
 | `GET /api/claim?token=...` | [`api/src/api/http/claim.rs:42`](../../api/src/api/http/claim.rs) | Server-rendered HTML form where the recipient sets email + password. Public route, token-gated. |
 
 The first three are gated by `is_full_admin`. The Synvya server pubkey is recognized as full admin via `ALLOWED_PUBKEYS` per the foundation spec.
 
 The fourth, `/api/claim`, is server-rendered HTML in Rust — **not** part of the SvelteKit web UI. It remains accessible when `DISABLE_WEB_UI=true` because the no-web-UI guard whitelists `/api/*`.
+
+The single-token endpoint `POST /api/admin/claim-tokens` is **not** consumed by this flow. The reason: it doesn't accept `delivery_email`, and we need Keycast to send the email (the Synvya server has no email infrastructure of its own). The batch endpoint already supports `delivery_email` and works correctly with a one-item array — calling it that way is the path of least resistance and requires zero Keycast change.
 
 ## 2. Vine-Flavored Field Repurposing
 
@@ -45,7 +47,8 @@ This is a small semantic wart — a non-Vine flow flowing through Vine-named fie
 If you are refactoring or simplifying these endpoints, please preserve:
 
 - The `vine_id` field on `preload-user` (or provide an alias). The Synvya server keys its preload + claim sequence on whatever value is sent in this field.
-- The `delivery_email` field semantics in `claim-tokens` (Synvya server may opt to use Keycast's email delivery instead of its own; see § 5 below).
+- The `delivery_email` field on `claim-tokens/batch` and the email-send branch at [`admin.rs:730`](../../api/src/api/http/admin.rs). Synvya admin provisioning depends on this — without it, new non-Nostr-native admins have no path to a Keycast account.
+- The behavior that Keycast iterates `vine_ids` and sends one email per token. A single-item array must result in one email; this is the shape Synvya admin provisioning relies on.
 - The `email_verified = true` outcome of a successful claim. Synvya admins must be able to log in immediately after claiming, without an additional verify-email round-trip.
 - The server-rendered `/api/claim` HTML page surviving with `DISABLE_WEB_UI=true`. Synvya production has no SvelteKit UI; the claim form is the recipient's only path to set a password.
 
@@ -53,19 +56,25 @@ If you are refactoring or simplifying these endpoints, please preserve:
 
 Once admin provisioning ships, expect a steady-state pattern of:
 
-- One `preload-user` + one `claim-tokens` call per Synvya admin onboard (Path B; "by email").
+- One `preload-user` + one `claim-tokens/batch` (single-item) call per Synvya admin onboard (Path B; "by email").
+- One outbound SES email per onboard (subject "Your Synvya account is ready to claim", from a `synvya.com` address).
 - Claim activity on `/api/claim` for those users.
 - New `users` and `personal_keys` rows for each claimed admin (same as any other Keycast registration).
 
 Volume is low (a handful of admin onboards per quarter at current Synvya scale).
 
-## 5. Email Delivery: Synvya-Side, Not Keycast
+## 5. Email: Keycast-Side
 
-The Synvya server sends the invitation email itself, using its existing email infrastructure (the same path that sends team invitations and password resets). The recipient's email comes **from a Synvya domain**, not from Keycast.
+The Synvya server **does not** have email infrastructure. **Keycast sends the claim email** as part of `claim-tokens/batch` when `delivery_email` is set. The path is the existing `send_claim_email` ([`api/src/email_service.rs:765`](../../api/src/email_service.rs)), which is also used today for Vine-import claim emails.
 
-The body contains the claim URL (which points at Keycast). The "From" header is Synvya. This keeps branding consistent and avoids Keycast email infra dependencies for this flow.
+The email content is generic Synvya branding:
 
-The Synvya server therefore does **not** use the `delivery_email` field on `claim-tokens` for the admin-provisioning flow. (It may use it for other flows; preserve the field's behavior regardless.)
+- Subject: `"Your Synvya account is ready to claim"`.
+- HTML: shared `basic_email_html` template when no kind-0 metadata is published (which is the case for fresh admin preloads — they have no kind-0 published yet). Generic call-to-action: "Your Synvya account is ready. Click the button below to claim it and set up your login."
+- Plain-text fallback with the same wording.
+- Link target: `{APP_URL}/api/claim?token={token}` (i.e. Keycast's claim form).
+
+For admin onboarding, this email **does not** say "you've been invited as an admin". The systemtools UI compensates by reminding the inviting superadmin to ping the recipient out-of-band so they're not surprised by the email. See [systemtools spec § After-submit confirmation](https://github.com/Synvya/systemtools/blob/staging/docs/specs/admin-user-provisioning.md). If we observe real confusion in practice, we can add an audience parameter to `send_claim_email` and tailor the template — but that is **future work, not this spec**.
 
 ## 6. Open Item
 

--- a/docs/synvya/keycast-service-auth.md
+++ b/docs/synvya/keycast-service-auth.md
@@ -38,10 +38,11 @@ New path:       NIP-98 header → UcanAuth { pubkey, admin_role }
 
 The composition order:
 
-1. If `Authorization: Nostr <base64-event>` is present, attempt NIP-98 verification.
-2. If verification succeeds, resolve `admin_role` from `ALLOWED_PUBKEYS` / `support_admins` Redis set, and return `UcanAuth`.
-3. Otherwise, fall back to the existing UCAN cookie path.
-4. If neither resolves, return 401.
+1. If `Authorization: Nostr <base64-event>` is present, the NIP-98 path is **exclusive**: verify the envelope and either resolve `admin_role` from `ALLOWED_PUBKEYS` / `support_admins` Redis set and return `UcanAuth`, or return 401. Do **not** fall through to the cookie path on NIP-98 failure.
+2. If the header is absent, fall back to the existing UCAN cookie path.
+3. If neither resolves, return 401.
+
+The exclusivity rule in step 1 is deliberate. A caller that sets `Authorization: Nostr ...` has explicitly declared "I am a service signing with NIP-98." Silently retrying as a cookie request on verification failure would hide NIP-98 errors from operators and could resolve the request under a different identity if a cookie happens to be in scope (dev sessions, shared browsers, CI). There is no legitimate caller that needs both paths tried in sequence.
 
 ## 3. NIP-98 Verification
 
@@ -79,7 +80,11 @@ The Synvya server signs every admin call with a fresh `created_at`. To prevent e
 - Store the id in Redis with a TTL slightly longer than the `created_at` tolerance window (e.g. `EXPIRE 120` seconds).
 - On each verification, `SET NX` on the id key. If the key already existed, reject as a replay.
 
-If Redis is unavailable, the verification falls back to "accept" — no replay protection, but the request still proceeds. This matches how `is_support_admin()` already handles Redis outages: log a warning, do not block.
+If Redis is unavailable, the anti-replay check **fails closed**: return 503 with a generic "service temporarily unavailable" body and log a warning. The verification does not proceed.
+
+Rationale: anti-replay is part of the authentication itself, not a downstream role check. Failing open would let a captured envelope be reused for the duration of a Redis outage, expanding the replay window from the ±60s `created_at` tolerance to "as long as Redis is down." Because NIP-98 service auth resolves to full-admin authority for the systemtools service pubkey (§4, §7), a replayed envelope is a high-impact credential. Fail-closed is the correct trade — service-to-service callers retry naturally on 503; brief Redis blips do not compromise auth.
+
+Note: this differs from how `is_support_admin()` handles Redis outages (it logs and returns false, treating the caller as non-support). That fallback is safe because the request is already authenticated and the failure mode is *capability downgrade*. Anti-replay sits earlier in the pipeline and a fallback there is *authentication weakening*.
 
 ## 6. Performance
 
@@ -112,8 +117,9 @@ The server pubkey (derived from `SERVER_BUNKER_CLIENT_PRIVATE_KEY`) must be in `
   - [ ] Stale `created_at` → 401.
   - [ ] Tampered signature → 401.
   - [ ] Replayed envelope (same id within TTL) → 401.
-  - [ ] Redis unavailable during anti-replay check → request proceeds (warning logged).
+  - [ ] Redis unavailable during anti-replay check → 503, request rejected (warning logged).
   - [ ] UCAN cookie still works on routes that previously accepted it.
+  - [ ] Request with both an invalid `Authorization: Nostr ...` header and a valid UCAN cookie → 401 (NIP-98 path is exclusive when the header is present).
 
 ## 9. Out of Scope
 

--- a/docs/synvya/keycast-service-auth.md
+++ b/docs/synvya/keycast-service-auth.md
@@ -1,0 +1,129 @@
+# Keycast Service Auth
+
+Keycast-vantage-point spec for the cross-repo "Keycast service auth" foundation. Defines how Keycast accepts authenticated, request-bound NIP-98 envelopes on admin routes and resolves them to a full-admin context when the signing pubkey is in `ALLOWED_PUBKEYS`.
+
+The same foundation has parallel specs in the other repos:
+
+- [Cross-system `keycast-service-auth.md`](https://github.com/Synvya/docs/blob/main/architecture/keycast-service-auth.md) — system-wide rationale and trust model.
+- [Server `keycast-service-auth.md`](https://github.com/Synvya/server/blob/staging/docs/specs/keycast-service-auth.md) — TypeScript implementation of the `KeycastAdminClient` that signs envelopes.
+
+**System context** (Keycast):
+
+- [Architecture Context](architecture-context.md)
+- [Keycast Boundary](specs/keycast-boundary.md)
+- [Support Users](support-users.md) — first consumer of this foundation.
+
+---
+
+## 1. Scope
+
+Keycast already verifies kind:27235 (NIP-98) envelopes during NIP-98 login at [`api/src/api/http/auth.rs:559`](../../api/src/api/http/auth.rs) and stamps `admin_role: "full" | "support"` into the issued UCAN cookie. After login, all subsequent admin requests are authorized by that cookie via the `UcanAuth` extractor.
+
+This spec extends the same NIP-98 primitive to **any admin route, not just login**. A request that arrives carrying a NIP-98 envelope in the `Authorization: Nostr ...` header is verified per-request and resolved to an `admin_role` directly, without going through login or holding a cookie.
+
+The new path is **additive**. It does not replace the UCAN cookie path. Existing callers (browsers, Restaurant app, systemtools UI) continue to work unchanged.
+
+## 2. Receiving Surface
+
+The new auth path is composed into the existing `UcanAuth` extractor. Handlers do not need to know which path the request came in on — they read `auth.pubkey` and `auth.admin_role` exactly as today.
+
+```
+Existing path:  UCAN cookie  → UcanAuth { pubkey, admin_role }
+New path:       NIP-98 header → UcanAuth { pubkey, admin_role }
+                                       ▲
+                                       │
+                       composed into UcanAuth so all admin routes
+                       accept either path transparently
+```
+
+The composition order:
+
+1. If `Authorization: Nostr <base64-event>` is present, attempt NIP-98 verification.
+2. If verification succeeds, resolve `admin_role` from `ALLOWED_PUBKEYS` / `support_admins` Redis set, and return `UcanAuth`.
+3. Otherwise, fall back to the existing UCAN cookie path.
+4. If neither resolves, return 401.
+
+## 3. NIP-98 Verification
+
+For each request bearing the NIP-98 header, verify in this order:
+
+1. The header value parses as `Nostr <base64>`. Decode the base64 to a JSON string, parse to a Nostr event.
+2. The event's `kind` is `27235`.
+3. The event's signature is valid for the claimed pubkey.
+4. The event has a `u` tag whose value matches the request's full URL (scheme, host, path, query — exactly).
+5. The event has a `method` tag whose value matches the HTTP method (uppercase).
+6. The event's `created_at` is within ±60 seconds of the server's clock.
+7. The event has not been seen before (anti-replay) — see §5.
+
+If any check fails, return 401 with a generic `unauthorized` body. Do not leak which specific check failed.
+
+## 4. Pubkey Resolution
+
+Once the envelope is verified, the signing pubkey is resolved to an admin role using the existing helpers in [`api/src/api/http/admin.rs:29`](../../api/src/api/http/admin.rs):
+
+- `is_full_admin(pubkey)` — pubkey is in `ALLOWED_PUBKEYS` env var (sourced from `synvya/{env}/keycast/allowed-pubkeys`), or the carried role is `full`.
+- `is_support_admin(pubkey)` — pubkey is in the `support_admins` Redis set (or the caller is already a full admin).
+
+The resulting `UcanAuth` carries:
+
+- `pubkey`: the verified pubkey from the envelope.
+- `admin_role`: `Some("full")`, `Some("support")`, or `None`.
+
+If `admin_role` is `None` (pubkey is recognized neither as full admin nor support admin), the handler that consumes `UcanAuth` may still see the request — the same as today for an authenticated non-admin user. Routes that require admin already check `is_full_admin`/`is_support_admin` themselves; this spec does not change those checks.
+
+## 5. Anti-Replay
+
+The Synvya server signs every admin call with a fresh `created_at`. To prevent envelope reuse, Keycast tracks recently-seen envelope IDs.
+
+- Compute the event id per NIP-01 (sha256 of canonical event serialization).
+- Store the id in Redis with a TTL slightly longer than the `created_at` tolerance window (e.g. `EXPIRE 120` seconds).
+- On each verification, `SET NX` on the id key. If the key already existed, reject as a replay.
+
+If Redis is unavailable, the verification falls back to "accept" — no replay protection, but the request still proceeds. This matches how `is_support_admin()` already handles Redis outages: log a warning, do not block.
+
+## 6. Performance
+
+The NIP-98 verification path is invoked only on requests that arrive with the header — i.e., only the Synvya server's outbound calls. Browser traffic continues to use the cookie path and is unaffected.
+
+Per-request cost: one signature check (~50 µs on Curve25519), one `ALLOWED_PUBKEYS` string scan, one Redis `SET NX` (anti-replay). All bounded; suitable for the call frequency expected (admin operations are infrequent).
+
+## 7. Bootstrap
+
+The server pubkey (derived from `SERVER_BUNKER_CLIENT_PRIVATE_KEY`) must be in `ALLOWED_PUBKEYS` for verification to resolve to full admin. Bootstrap procedure:
+
+1. Read the existing nsec from `synvya/{env}/server/bunker-client-private-key` (managed by Synvya server ops; see [server spec](https://github.com/Synvya/server/blob/staging/docs/specs/keycast-service-auth.md)).
+2. Derive the hex pubkey.
+3. Append the pubkey to `synvya/{env}/keycast/allowed-pubkeys`. Existing bootstrap human pubkeys remain in place.
+4. Refresh the secret on the running Keycast process (deployment or in-process refresh, depending on environment).
+
+`ALLOWED_PUBKEYS` parsing is unchanged — see [`admin.rs:34`](../../api/src/api/http/admin.rs).
+
+## 8. Implementation Checklist
+
+- [ ] New module under `api/src/api/` (e.g. `nip98_extractor.rs`, or extend `extractors.rs`) implementing the verification + resolution flow per §3 and §4.
+- [ ] Compose into `UcanAuth` extractor at [`api/src/api/extractors.rs:62`](../../api/src/api/extractors.rs) so any handler accepting `UcanAuth` accepts either NIP-98 header or UCAN cookie.
+- [ ] Anti-replay store using the existing Redis client (already wired into `KeycastState`).
+- [ ] Tests:
+  - [ ] Valid envelope from a pubkey in `ALLOWED_PUBKEYS` → `admin_role: "full"`.
+  - [ ] Valid envelope from a pubkey in `support_admins` Redis → `admin_role: "support"`.
+  - [ ] Valid envelope from a known but non-admin pubkey → `admin_role: None`, request proceeds (handler may still reject).
+  - [ ] Mismatched `u` tag → 401.
+  - [ ] Mismatched `method` tag → 401.
+  - [ ] Stale `created_at` → 401.
+  - [ ] Tampered signature → 401.
+  - [ ] Replayed envelope (same id within TTL) → 401.
+  - [ ] Redis unavailable during anti-replay check → request proceeds (warning logged).
+  - [ ] UCAN cookie still works on routes that previously accepted it.
+
+## 9. Out of Scope
+
+- The actual admin endpoints called via this path (`add_support_admin`, `preload_user`, etc.) — those exist or are added by their consumer specs ([Support Users](support-users.md), `admin-user-provisioning`).
+- Per-call human-attribution headers (`X-Acting-As`). A future enhancement; not in v1.
+- Tenant-scoping of the recognition path. The current `support_admins` set and `ALLOWED_PUBKEYS` are global. If multi-tenant operator separation becomes a requirement, both stores need namespacing — a separate spec.
+
+## 10. Consumer Specs
+
+The following specs build on this foundation and assume the NIP-98 service-auth path is in place:
+
+- [Support Users](support-users.md) — uses NIP-98 service auth so the Synvya server can mirror Support flag toggles into the `support_admins` Redis set.
+- `admin-user-provisioning` (forthcoming) — uses NIP-98 service auth so the server can call `preload_user` and `claim-tokens` on behalf of `systemtools` superadmins.

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -6,6 +6,7 @@ Spec for letting Synvya support staff create restaurants on behalf of owners and
 - [Cross-system `support-users.md`](https://github.com/Synvya/docs/blob/main/architecture/support-users.md) — system-wide design and the two-layer authority model.
 - [Server `support-users.md`](https://github.com/Synvya/server/blob/staging/docs/specs/support-users.md) — Synvya server's Support-flag mirror to Keycast.
 - [Systemtools `support-users.md`](https://github.com/Synvya/systemtools/blob/staging/docs/specs/support-users.md) — UI: Support toggle on the admin user row, DynamoDB attribute.
+- [Client `support-users.md`](https://github.com/Synvya/client/blob/staging/docs/specs/support-users.md) — Restaurant app: support picker, support-access wiring, session cleanup on switch and logout.
 
 **System context** (Keycast):
 - [Keycast Service Auth](keycast-service-auth.md) — foundation; the Synvya server's mirror call to Keycast rides on this NIP-98 service-auth path.
@@ -127,6 +128,8 @@ The existing `create_with_admin` repository call ([`core/src/repositories/team.r
 
 ### 3.2 New endpoint: `POST /api/admin/teams/:id/support-access`
 
+The `/support-access` endpoints target **fully-provisioned teams** — the existing-restaurant diagnostic flow (§5.2). For the cold-start flow (§5.1), the support user is already the team's admin via `create_with_admin` and uses the standard team-admin endpoints (`add_key`, `add_authorization`, `invite_user`); they never call `POST /support-access` for a team they just created.
+
 **Auth**: `is_support_admin()` only. Tenant-scoped via `TenantExtractor`.
 
 **Path params**: `id` — team id.
@@ -134,17 +137,20 @@ The existing `create_with_admin` repository call ([`core/src/repositories/team.r
 **Request body**:
 ```json
 {
-  "policy_id": 42,           // optional; defaults to the team's "All Access" policy
-  "label": "support: maria"  // optional; recorded on the authorization for audit clarity
+  "policy_id": 42,            // optional; defaults to the team's "All Access" policy
+  "label": "support: maria",  // optional; the server prefixes with `support:{caller_pubkey}` for filtering
+  "expires_in_hours": 24      // optional; default 24, server-enforced ceiling 168 (7d)
 }
 ```
 
 **Behavior** (single transaction):
 1. Look up the team and verify it belongs to the caller's tenant.
-2. If the caller is not yet a `team_users` row for this team, insert one with `role = 'member'`. If the caller is already a member, leave the row alone (do not downgrade an admin).
-3. Pick the team's first non-revoked stored key (this is the restaurant identity; teams have exactly one in the current Synvya model).
-4. Mint a fresh `Authorization` against that stored key, with `connected_client_pubkey = caller`, derived bunker keys, and a fresh connection secret. Use the existing `auth_repo.create()` path so the signer daemon picks it up.
-5. Return the bunker URL plus the authorization summary.
+2. If the team has no non-revoked stored key, return **400** (`team has no stored key — the agent who created it must finish provisioning first`). The endpoint is for established teams.
+3. If the caller is not yet a `team_users` row for this team, insert one with `role = 'member'`. If the caller is already a member, leave the row alone (do not downgrade an admin).
+4. Pick the team's first stored key (the restaurant identity; teams have exactly one in the current Synvya model).
+5. Mint a fresh `Authorization` against that stored key with derived bunker keys, a fresh connection secret, `expires_at` per request (default 24h, capped at 7d), and `label = "support:{caller_pubkey_hex}"` (request-supplied label is appended after the prefix). The label is the source of truth for the `DELETE` endpoint's filtering — `connected_client_pubkey` is set later by the signer when the bunker is first used.
+6. Notify the signer daemon via `AuthorizationCommand::Upsert` so the bunker is live without lazy-load latency.
+7. Return the bunker URL plus the authorization summary.
 
 **Response**:
 ```json
@@ -163,9 +169,11 @@ The existing `create_with_admin` repository call ([`core/src/repositories/team.r
 **Auth**: `is_support_admin()` only. Tenant-scoped.
 
 **Behavior** (single transaction):
-1. Find all non-revoked authorizations on this team where `connected_client_pubkey = caller`. Set `revoked_at = NOW()` and `revoked_reason = 'support_session_end'` on each. Notify the signer daemon (`AuthorizationCommand::Remove`) for each one, mirroring [`admin.rs:1138`](../../api/src/api/http/admin.rs).
+1. Find all non-revoked authorizations on this team where `label LIKE 'support:{caller_pubkey_hex}%'`. Set `revoked_at = NOW()` and `revoked_reason = 'support_session_end'` on each. Notify the signer daemon (`AuthorizationCommand::Remove`) for each one, mirroring [`admin.rs:1138`](../../api/src/api/http/admin.rs).
 2. If the caller's `team_users` row has `role = 'member'` (not `admin`), remove it. If they are an `admin` of this team (e.g., they created it), leave the membership alone.
 3. Return a count of revoked authorizations and a `removed_membership: bool`.
+
+The label-based filter is required because `connected_client_pubkey` is populated only when a NIP-46 client first connects; for a freshly minted authorization that has not yet been used, the column is `NULL`. The grant endpoint stamps `label = "support:{caller_pubkey_hex}"` so this filter unambiguously identifies the calling agent's own authorizations.
 
 **Response**:
 ```json

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -2,7 +2,13 @@
 
 Spec for letting Synvya support staff create restaurants on behalf of owners and act as any existing restaurant identity for diagnostic/repair work, all from inside the Synvya Restaurant app (`account.synvya.com`).
 
-**System context**:
+**Per-repo specs**:
+- [Cross-system `support-users.md`](https://github.com/Synvya/docs/blob/main/architecture/support-users.md) — system-wide design and the two-layer authority model.
+- [Server `support-users.md`](https://github.com/Synvya/server/blob/staging/docs/specs/support-users.md) — Synvya server's Support-flag mirror to Keycast.
+- [Systemtools `support-users.md`](https://github.com/Synvya/systemtools/blob/staging/docs/specs/support-users.md) — UI: Support toggle on the admin user row, DynamoDB attribute.
+
+**System context** (Keycast):
+- [Keycast Service Auth](keycast-service-auth.md) — foundation; the Synvya server's mirror call to Keycast rides on this NIP-98 service-auth path.
 - [Architecture Context](architecture-context.md)
 - [Keycast Boundary](specs/keycast-boundary.md)
 - [Restaurant Team E2E](restaurant-team-e2e.md)
@@ -30,13 +36,13 @@ The `support_admin` role already grants read access to a user's teams and author
 
 ### Defining who is a support agent
 
-`systemtools` is the source of truth for who is a Synvya support agent. Keycast's `support_admins` Redis set is a **managed mirror** that the `systemtools` backend keeps in sync — it is never edited by humans directly.
+`systemtools` is the source of truth for who is a Synvya support agent. Keycast's `support_admins` Redis set is a **managed mirror** kept in sync by the Synvya server — it is never edited by humans directly.
 
-Concretely, `systemtools`' admin user record gains a `support` flag, **orthogonal** to the existing `pulse_only | admin | superadmin` role (a user can have `support: true` independently of any systemtools-UI role). When a `systemtools` `superadmin` toggles the flag on a user, the `systemtools` backend (a) updates its DynamoDB admin table, and (b) calls Keycast `POST /api/admin/support-admins` (or the matching `DELETE` on demotion) to update the Redis mirror. Next time that user logs into Keycast, `is_support_admin()` returns true and the issued UCAN carries `admin_role: "support"`.
+Concretely, the `systemtools` admin user record gains a `support` flag, **orthogonal** to the existing `pulse_only | admin | superadmin` role (a user can have `support: true` independently of any systemtools-UI role). When a `systemtools` `superadmin` toggles the flag on a user, the Synvya server (a) updates its DynamoDB admin table, and (b) calls Keycast `POST /api/admin/support-admins` (or the matching `DELETE` on demotion) to update the Redis mirror. Next time that user logs into Keycast, `is_support_admin()` returns true and the issued UCAN carries `admin_role: "support"`.
 
-For step (b) to authorize against Keycast, the `systemtools` backend signs each call with NIP-98 using a dedicated service identity. Keycast calls pubkeys listed in `ALLOWED_PUBKEYS` **full admins** — operator-level identities with full Keycast authority. The `systemtools` service pubkey is one such full admin, added to the `synvya/{env}/keycast/allowed-pubkeys` secret once at bootstrap. Bootstrap human full admins (Synvya leadership/engineering with direct Keycast authority) are added to the same secret manually and managed by the same secret-update process.
+The mirror call from server to Keycast goes over the [Keycast Service Auth](keycast-service-auth.md) foundation: signed with `SERVER_BUNKER_CLIENT_PRIVATE_KEY` (the server's existing stable identity), recognized by Keycast as full admin via `ALLOWED_PUBKEYS`. See the foundation spec for the complete mechanism, the bootstrap procedure, and the trust model. This spec assumes the foundation is in place.
 
-The `systemtools` `superadmin` role does **not** automatically grant Keycast full admin. They are independent: a Synvya leader who needs direct Keycast authority is in `ALLOWED_PUBKEYS` *and* has the systemtools `superadmin` role, by separate operations. This is the deliberate manual-sync boundary.
+The `systemtools` `superadmin` role does **not** automatically grant Keycast full admin. They are independent: a Synvya leader who needs direct Keycast authority is in `ALLOWED_PUBKEYS` *and* has the systemtools `superadmin` role, by separate operations.
 
 ### What the Restaurant app does after this lands
 
@@ -70,25 +76,27 @@ The `support_admins` Redis set is tenant-global (single key, not namespaced by t
 - New endpoints for atomic just-in-time support access on existing teams:
   - `POST /api/admin/teams/:id/support-access` — add the calling support admin as member of the team, mint a fresh `Authorization` against the team's first stored key, return the bunker URL.
   - `DELETE /api/admin/teams/:id/support-access` — revoke the support admin's active authorizations on the team and remove their membership.
-- A NIP-98 (kind:27235) service-auth path that resolves a request-bound signed envelope to a full-admin context when the signing pubkey is in `ALLOWED_PUBKEYS`. This is what lets the `systemtools` backend write to `support_admins` without needing a human's session cookie.
-- Audit log lines for both new endpoints and the systemtools-mirror operation, mirroring the `revoke_authorization` log pattern.
+- Audit log lines for both new endpoints, mirroring the `revoke_authorization` log pattern.
+
+The NIP-98 service-auth path used by the Synvya server's mirror call is **not new in this spec** — it is owned by the [Keycast Service Auth](keycast-service-auth.md) foundation and is a prerequisite.
 
 ### What `systemtools` owns (new)
 
 - A `support` flag on the existing admin user record (DynamoDB `synvya-{env}-admin-users`), orthogonal to the existing role enum.
-- A "Support" management surface in the `systemtools` UI (visible to `superadmin` only) that toggles the flag on/off for any existing admin user.
-- A backend mirror that, on each toggle, also calls Keycast `POST /api/admin/support-admins` (or `DELETE`) signed with NIP-98 by the systemtools service identity.
-- A bootstrap configuration: the systemtools service nsec held in AWS Secrets Manager; the corresponding pubkey listed in `synvya/{env}/keycast/allowed-pubkeys`.
+- A "Support" toggle in the `systemtools` UI (visible to `superadmin` only) on the admin user row.
+- A backend mirror in the Synvya server that, on each toggle, also calls Keycast `POST /api/admin/support-admins` (or `DELETE`) via the foundation service-auth path.
+
+Bootstrap of `ALLOWED_PUBKEYS` (i.e. registering the Synvya server's pubkey as a Keycast full admin) is owned by the [Keycast Service Auth](keycast-service-auth.md) foundation. This spec depends on it but does not duplicate it.
 
 ### What Keycast does not own
 
 - The Restaurant app's restaurant picker UI, "Create new restaurant" button, and "Open another restaurant" search. Those live in `Synvya/client`.
 - The systemtools-side Support management UI and the DynamoDB `support` flag. Those live in `systemtools` (frontend) and the Synvya server (backend, mirroring to Keycast).
-- The contents of `ALLOWED_PUBKEYS`. The bootstrap manual-sync of Synvya leadership/engineering pubkeys and the systemtools service pubkey is operational, not a Keycast feature.
+- The contents of `ALLOWED_PUBKEYS`, the NIP-98 service-auth verification path, and the server's signing identity. Owned by the [Keycast Service Auth](keycast-service-auth.md) foundation.
 
 ### What `Synvya/server` does not own
 
-`Synvya/server` is not in the request path for any user-facing support action. The systemtools backend (which today lives inside `Synvya/server`) is in the path only for management operations (toggling the Support flag), not for the support actions themselves. The unused `KEYCAST_SERVICE_TOKEN` in `Synvya/server`'s config remains unused — it is replaced by NIP-98 signing with the systemtools service nsec.
+`Synvya/server` is not in the request path for any user-facing support action. The systemtools backend (which lives inside `Synvya/server`) is in the path only for management operations (toggling the Support flag), not for the support actions themselves.
 
 ---
 
@@ -182,21 +190,6 @@ Both new routes are registered alongside the existing admin block at [`api/src/a
 )
 ```
 
-### 3.5 NIP-98 service-auth path on admin routes
-
-Keycast already verifies kind:27235 (NIP-98) envelopes during NIP-98 login at [`api/src/api/http/auth.rs:559`](../../api/src/api/http/auth.rs) and stamps `admin_role: "full" | "support"` into the issued UCAN. This spec extends the same primitive to **any admin route**, not just login:
-
-- A request carrying `Authorization: Nostr <base64(kind:27235 event)>` is verified the same way (signature valid, `u` tag matches request URL, `method` tag matches HTTP method, `created_at` within tolerance).
-- If the signing pubkey is in `ALLOWED_PUBKEYS`, the request is treated as if it carried a full-admin UCAN. `is_full_admin()` returns true for that request.
-- If the signing pubkey is in the `support_admins` Redis set, the request is treated as `admin_role: "support"`.
-- Otherwise the envelope is rejected.
-
-This middleware is the entry point the `systemtools` backend uses when it calls `POST /api/admin/support-admins`: the call is signed with the systemtools service nsec, and Keycast resolves the service pubkey to full-admin authority via this path. No session cookie, no shared secret token. Each request is independently authenticated by signature.
-
-Keep the existing UCAN cookie path untouched — it remains the primary auth mechanism for human callers (Restaurant app, future systemtools UI calls that piggyback on a user's keycast session). NIP-98 service-auth is an additional path, not a replacement.
-
-The middleware lives in `api/src/api/extractors.rs` (or a new file `api/src/api/nip98_extractor.rs`) and is composed into the same `UcanAuth` extractor so handlers do not need to know which path the request came in on.
-
 ---
 
 ## 4. Reused Surface (no changes)
@@ -211,7 +204,7 @@ The following are already implemented and gated on `is_support_admin()` ([`api/s
 | `POST /api/admin/authorizations/:id/revoke` | Manual revoke for diagnostics; complements the bulk revoke in `DELETE .../support-access` |
 | `GET /api/admin/claim-tokens?pubkey=` | Look up a pending claim token for handoff |
 | `POST /api/admin/claim-tokens` | Generate a claim link to hand off the new restaurant to its owner |
-| `POST /api/admin/support-admins` | Full-admin only. Called by the `systemtools` backend (NIP-98-signed by the systemtools service identity) when a `superadmin` toggles the Support flag on a user. Not called by humans directly in Phase 2. |
+| `POST /api/admin/support-admins` | Full-admin only. Called by the Synvya server backend via the [foundation service-auth path](keycast-service-auth.md) when a `superadmin` toggles the Support flag on a user. Not called by humans directly. |
 | `DELETE /api/admin/support-admins/:pubkey` | Full-admin only. Same caller as above; invoked on demotion. |
 
 For team-internal operations after `create_team` (adding a stored key, creating the first server-side authorization for `Synvya/server`, inviting the actual owner by email), the support user uses the existing team-admin endpoints by virtue of being the team's admin. Specifically:
@@ -337,7 +330,7 @@ No structured audit table is added in this spec; the structured log lines feed C
 
 5. **Stored key access**. Support admins never touch the restaurant's stored secret key directly. They sign via NIP-46 against an authorization they hold, exactly like any other team member. The encryption-at-rest model is unchanged.
 
-6. **Systemtools service identity**. The systemtools service nsec is a full-admin credential — anyone holding it can do anything in Keycast. It must be stored only in AWS Secrets Manager, never logged, never passed through frontend code, and never used outside the systemtools backend. Compromise of this nsec is equivalent to compromise of a Keycast root credential and is handled by rotating the value in Secrets Manager and updating `synvya/{env}/keycast/allowed-pubkeys`.
+6. **Service-auth credentials**. The credential used by the Synvya server to sign mirror calls to Keycast is `SERVER_BUNKER_CLIENT_PRIVATE_KEY`. Security details — handling, blast radius, rotation procedure — are owned by the [Keycast Service Auth](keycast-service-auth.md) foundation spec.
 
 7. **Demotion is eventually consistent**. When a `superadmin` removes the Support flag from a user, the user's UCAN may still carry `admin_role: "support"` until it expires (UCANs are stamped at login, not re-checked on every request). For immediate revocation, the systemtools backend should also revoke the user's active Keycast sessions via existing session-management endpoints, or accept that Support powers persist until UCAN expiry. The current Keycast UCAN TTL is short enough (minutes) that this is acceptable for normal demotions; emergency demotions (terminated employees) require explicit session revocation.
 
@@ -351,7 +344,6 @@ Keycast (`synvya-staging` branch):
 - [ ] Add `grant_team_support_access` handler in [`api/src/api/http/admin.rs`](../../api/src/api/http/admin.rs).
 - [ ] Add `release_team_support_access` handler in the same file.
 - [ ] Register both routes under `/admin/teams/:id/support-access` in [`api/src/api/http/routes.rs`](../../api/src/api/http/routes.rs).
-- [ ] Add NIP-98 service-auth extractor (§3.5) and compose it into `UcanAuth` so any admin route accepts either a UCAN cookie or a request-bound NIP-98 envelope.
 - [ ] Add structured log lines per §7.
 - [ ] Default authorization expiry of 24h on support-issued authorizations (per §8.2). Make configurable via request body.
 - [ ] Tests:
@@ -361,9 +353,6 @@ Keycast (`synvya-staging` branch):
   - [ ] release notifies the signer daemon (`AuthorizationCommand::Remove`).
   - [ ] full admin retains all current capabilities.
   - [ ] non-support, non-admin caller is forbidden on both new endpoints.
-  - [ ] NIP-98-signed call from a pubkey in `ALLOWED_PUBKEYS` resolves to full-admin and can `POST /api/admin/support-admins`.
-  - [ ] NIP-98-signed call from a pubkey not in `ALLOWED_PUBKEYS` and not in `support_admins` is rejected.
-  - [ ] NIP-98 envelope with mismatched `u` tag, mismatched `method` tag, or stale `created_at` is rejected.
 
 Restaurant app (`Synvya/client`, separate PR):
 
@@ -373,28 +362,18 @@ Restaurant app (`Synvya/client`, separate PR):
 - [ ] On active-team switch / logout, call `DELETE .../support-access` if the leaving team was a support session.
 - [ ] Distinct UI label for support members on the Team page.
 
-`systemtools` and Synvya server backend (separate PR):
+`systemtools` and Synvya server checklists are in their respective vantage-point specs:
 
-- [ ] Add `support: boolean` attribute to `synvya-{env}-admin-users` DynamoDB items (default false on existing rows).
-- [ ] Add `support` to the `AdminUser` TypeScript type and the `SessionInfo` shape returned by `GET /api/admin/me`.
-- [ ] Render a "Support" toggle in the systemtools admin user management page (already a Phase 4 placeholder), gated on `superadmin` role.
-- [ ] Backend handler for the toggle: write DynamoDB, then call Keycast `POST /api/admin/support-admins` (or `DELETE /api/admin/support-admins/:pubkey` on demotion) with NIP-98 signing.
-- [ ] `KeycastAdminClient` service (~150 LOC): holds the systemtools service nsec from AWS Secrets Manager; signs each call with NIP-98 (URL + method + timestamp tags); retries with exponential backoff on transient errors.
-- [ ] Idempotency: if the DynamoDB write succeeds but the Keycast mirror call fails, the toggle is marked "drift" and a sweeper job reconciles. Drift is also surfaced in the admin UI as a warning.
-- [ ] Tests: end-to-end toggle promotes/demotes the user in both DynamoDB and Keycast Redis; failure of the Keycast call is captured as drift; idempotent re-toggle is a no-op.
+- [Server `support-users.md`](https://github.com/Synvya/server/blob/staging/docs/specs/support-users.md) — DynamoDB attribute, `KeycastAdminClient.addSupportAdmin/removeSupportAdmin`, drift handling, mirror endpoint.
+- [Systemtools `support-users.md`](https://github.com/Synvya/systemtools/blob/staging/docs/specs/support-users.md) — Support toggle UI, badge, drift indicator.
 
-Operations:
-
-- [ ] Generate the systemtools service nsec; store as `synvya/{env}/systemtools/keycast-service-key` in AWS Secrets Manager.
-- [ ] Add the corresponding pubkey to `synvya/{env}/keycast/allowed-pubkeys` alongside the existing bootstrap pubkeys.
-- [ ] Document the manual sync runbook for adding/removing Synvya leadership/engineering pubkeys to/from `allowed-pubkeys`.
+Operations bootstrap (registering the Synvya server's pubkey in `ALLOWED_PUBKEYS`) is owned by the [Keycast Service Auth](keycast-service-auth.md) foundation spec.
 
 ---
 
 ## 10. Out of Scope / Future Work
 
 - **Tenant-scoped support admins**. Today the `support_admins` Redis set is keyed `support_admins` (single key). If Keycast becomes multi-tenant in Synvya, the set should be namespaced per tenant (`support_admins:{tenant_id}`) and `is_support_admin` should consult the caller's tenant. Not needed yet.
-- **Automatic ALLOWED_PUBKEYS sync**. Bootstrap full-admin membership is intentionally manual. Removing this manual step would either require systemtools to manage `ALLOWED_PUBKEYS` (which would mean systemtools could elevate itself or any of its users to Keycast full admin — a much larger blast radius than the Support flag), or a separate identity system. Both are larger than the problem currently warrants.
 - **Auto-expire of stale support sessions**. Beyond the 24h authorization expiry, a periodic sweeper that revokes any `support` authorizations older than N hours would reduce the leak surface in §8.2. Defer until we see real volume.
 - **Read-only support mode**. A support admin could be granted "view this team's data" without minting a signing authorization. Not in this spec — current Synvya support tasks are write-leaning (fix bad menu data, repair profile fields).
 - **Formal audit table**. Once support volume justifies it, move from `tracing::info!` to a structured `admin_audit_log` table with `(actor_pubkey, action, target_team_id, target_authorization_id, outcome, ts, request_id)` columns.
@@ -421,11 +400,10 @@ A single Synvya employee can hold any combination: e.g., an engineer might be a 
 
 1. Synvya `superadmin` opens the `systemtools` admin user page for the target user.
 2. Toggles the **Support** checkbox to on.
-3. `systemtools` backend writes `support: true` to the DynamoDB row.
-4. `systemtools` backend builds a kind:27235 NIP-98 envelope: `u` = `https://auth.synvya.com/api/admin/support-admins`, `method` = `POST`, signed with the systemtools service nsec.
-5. `systemtools` backend sends `POST /api/admin/support-admins` to Keycast with `Authorization: Nostr <base64(envelope)>` and body `{ "identifier": "<target user's pubkey or email>" }`.
-6. Keycast verifies the envelope, resolves the systemtools service pubkey to full-admin via `ALLOWED_PUBKEYS`, runs the existing `add_support_admin` handler, and writes to Redis.
-7. Next time the target user logs into Keycast, `is_support_admin()` returns true and their UCAN carries `admin_role: "support"`.
+3. Synvya server writes `support: true` to the DynamoDB row.
+4. Synvya server calls Keycast `POST /api/admin/support-admins` over the [foundation service-auth path](keycast-service-auth.md) (signed with `SERVER_BUNKER_CLIENT_PRIVATE_KEY`) with body `{ "identifier": "<target user's pubkey or email>" }`.
+5. Keycast verifies the envelope per the foundation, runs the existing `add_support_admin` handler, and writes to Redis.
+6. Next time the target user logs into Keycast, `is_support_admin()` returns true and their UCAN carries `admin_role: "support"`.
 
 ### Demotion flow (toggle Support flag off)
 
@@ -433,14 +411,7 @@ Symmetric to promotion: DynamoDB write, then `DELETE /api/admin/support-admins/:
 
 ### Bootstrap (one-time, per environment)
 
-Run once when standing up a new staging or production environment, or when rotating credentials:
-
-1. Generate a fresh nsec for the systemtools service identity.
-2. Store as `synvya/{env}/systemtools/keycast-service-key` in AWS Secrets Manager.
-3. Compute the corresponding hex pubkey.
-4. Edit `synvya/{env}/keycast/allowed-pubkeys` to append the systemtools service pubkey alongside the existing bootstrap human pubkeys.
-5. Redeploy or trigger the secret-refresh path on Keycast so the new `ALLOWED_PUBKEYS` is loaded.
-6. Verify by issuing a test NIP-98-signed `GET /api/admin/support-admins` from the systemtools backend and confirming a `200` response.
+Bootstrap (registering the Synvya server's pubkey in `ALLOWED_PUBKEYS`) is owned by the [Keycast Service Auth](keycast-service-auth.md) foundation. Once that bootstrap is complete for an environment, no additional Keycast bootstrap is required for the support-users feature.
 
 ### Adding or removing a Synvya leadership/engineering full admin
 

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -219,6 +219,44 @@ Behavior:
 
 The unit-tested helper `mark_support_members(rows: &mut [TeamUser], set: &HashSet<String>)` is the pure core; the handler-side `fetch_support_admin_set()` performs the I/O.
 
+### 3.6 New endpoint: `GET /api/admin/team-lookup`
+
+The primary search surface for the Restaurant app's "Open another restaurant" picker (§5.2). Lets a support agent find a restaurant by name rather than going through the owner.
+
+**Auth**: `is_support_admin()` only. Tenant-scoped via `TenantExtractor`.
+
+**Query params**:
+
+| Param | Description |
+|---|---|
+| `q` | Required. Case-insensitive substring of the team name. Minimum 2 characters. |
+
+**Response**:
+
+```json
+{
+  "results": [
+    {
+      "id": 17,
+      "name": "Joe's Diner",
+      "admin_emails": ["joe@example.com"],
+      "has_stored_key": true,
+      "created_at": "2025-09-12T14:03:11Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+**Behavior**:
+
+- Single SQL query with `ILIKE '%q%'` on `teams.name`, joined to `team_users` and `users` to aggregate admin emails (deduped, admins only — `member` rows are excluded), and an `EXISTS` subquery against `stored_keys` for the provisioning flag.
+- Results are tenant-scoped, sorted by name, capped at **25 rows** (`TEAM_LOOKUP_LIMIT`).
+- Queries shorter than 2 chars return 400; this is intentional — too short to render in a picker without overwhelming.
+- `has_stored_key: false` rows are still returned so the client can show the team but disable the "Open" action with a message ("not yet provisioned"); per §3.2, `POST /support-access` would 400 on those teams.
+
+**Why a name search rather than user-rooted**: support agents most often start from "this restaurant has a problem," not "this user has a problem." The owner-rooted `user-lookup` + `user-teams` flow is retained for the cases that genuinely begin from a user (claim-token lookup, revoking a specific user's authorizations) but is no longer the primary path for finding a restaurant.
+
 ---
 
 ## 4. Reused Surface (no changes)

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -198,6 +198,27 @@ Both new routes are registered alongside the existing admin block at [`api/src/a
 )
 ```
 
+### 3.5 `is_support_member` enrichment on team responses
+
+Existing team responses gain a per-`TeamUser` boolean so the Restaurant app can label support agents distinctly without holding any admin role. No new routes; the change is additive on the existing payload shape.
+
+Endpoints affected:
+
+| Endpoint | Returns |
+|---|---|
+| `GET /api/teams` | `Vec<TeamWithRelations>` — each `team_users` row carries `is_support_member`. |
+| `GET /api/teams/:id` | `TeamWithRelations` — same enrichment. |
+| `POST /api/teams/:id/users` | `TeamUser` — single row, enriched. |
+
+Behavior:
+
+- For each request, the handler does **one** Redis `SMEMBERS support_admins` call, builds a `HashSet`, and flags any `team_users.user_pubkey` that appears in the set as `is_support_member = true`.
+- When Redis is unavailable (state error, connection failure, missing client), the handler logs a warning and returns `is_support_member: false` for all rows. Capability downgrade, never a hard failure — the response stays valid.
+- The flag is **not stored in the database**. It reflects current support-admin status at request time. A user toggled out of `support_admins` will stop being flagged on the next request after the toggle propagates.
+- Existing clients that ignore unknown fields are unaffected. Clients that read `is_support_member` get the enrichment without any other API change.
+
+The unit-tested helper `mark_support_members(rows: &mut [TeamUser], set: &HashSet<String>)` is the pure core; the handler-side `fetch_support_admin_set()` performs the I/O.
+
 ---
 
 ## 4. Reused Surface (no changes)
@@ -332,7 +353,7 @@ No structured audit table is added in this spec; the structured log lines feed C
 
 2. **JIT membership leak**. If `release_team_support_access` is never called (browser crashes, network failure, the support admin closes their laptop without logging out), the support admin remains a member with a live authorization until either (a) the authorization expires or (b) another support admin manually revokes via `revoke_authorization`. To bound this, support-issued authorizations are minted with a short `expires_at` (default 24h, configurable per call). The signer daemon enforces expiry.
 
-3. **Restaurant owner visibility**. After this lands, a restaurant owner viewing their team membership list will see support admins listed alongside the owner during active support sessions. This is a feature, not a leak, but the Restaurant app should label support members distinctly so owners are not confused about who has access. The label is applied client-side based on `team_users.role = 'member'` plus a presence check against the `support_admins` set (read via `GET /api/admin/support-admins` if owner has visibility, or returned inline by `user-teams` for support; this is a client UX decision and out of scope for Keycast).
+3. **Restaurant owner visibility**. After this lands, a restaurant owner viewing their team membership list will see support admins listed alongside the owner during active support sessions. This is a feature, not a leak, but the Restaurant app should label support members distinctly so owners are not confused about who has access. Keycast surfaces the data the client needs by stamping `is_support_member: bool` on each `TeamUser` row in responses from `GET /teams`, `GET /teams/:id`, and `POST /teams/:id/users`; the flag is populated by cross-referencing each member's pubkey against the Redis `support_admins` set on the request path. The visual treatment of the flag (badge, parenthetical) is a client UX decision; the data path is owned by Keycast.
 
 4. **Audit trail tampering**. Support admins cannot delete or amend their own log lines; logs go to Cloud Logging via the standard request path.
 
@@ -348,19 +369,17 @@ No structured audit table is added in this spec; the structured log lines feed C
 
 Keycast (`synvya-staging` branch):
 
-- [ ] Widen `create_team` gate at [`api/src/api/http/teams.rs:68`](../../api/src/api/http/teams.rs) to call `is_support_admin().await`.
-- [ ] Add `grant_team_support_access` handler in [`api/src/api/http/admin.rs`](../../api/src/api/http/admin.rs).
-- [ ] Add `release_team_support_access` handler in the same file.
-- [ ] Register both routes under `/admin/teams/:id/support-access` in [`api/src/api/http/routes.rs`](../../api/src/api/http/routes.rs).
-- [ ] Add structured log lines per §7.
-- [ ] Default authorization expiry of 24h on support-issued authorizations (per §8.2). Make configurable via request body.
+- [x] Widen `create_team` gate at [`api/src/api/http/teams.rs:68`](../../api/src/api/http/teams.rs) to call `is_support_admin().await`.
+- [x] Add `grant_team_support_access` handler in [`api/src/api/http/admin.rs`](../../api/src/api/http/admin.rs).
+- [x] Add `release_team_support_access` handler in the same file.
+- [x] Register both routes under `/admin/teams/:id/support-access` in [`api/src/api/http/routes.rs`](../../api/src/api/http/routes.rs).
+- [x] Add structured log lines per §7.
+- [x] Default authorization expiry of 24h on support-issued authorizations (per §8.2). Make configurable via request body.
+- [x] Add `is_support_member` enrichment on team responses per §3.5 — populated via Redis `SMEMBERS support_admins` on the request path; no database change.
 - [ ] Tests:
-  - [ ] support admin can create a team; non-admin non-support user with one existing team membership cannot.
-  - [ ] support admin can grant + release access on a team they are not a member of; second release is a no-op.
-  - [ ] release does not remove `admin` membership (e.g., the support user who originally created the team).
-  - [ ] release notifies the signer daemon (`AuthorizationCommand::Remove`).
-  - [ ] full admin retains all current capabilities.
-  - [ ] non-support, non-admin caller is forbidden on both new endpoints.
+  - [x] `find_active_support_for_caller` filter: label-prefix matching, revoked exclusion, team scoping, suffix tolerance.
+  - [x] `mark_support_members` helper: only set members flagged, idempotent, empty-set no-op, preexisting flag preserved.
+  - [ ] HTTP-handler tests for grant + release behavior — deferred until an admin-endpoint test harness is established.
 
 Restaurant app (`Synvya/client`, separate PR):
 

--- a/docs/synvya/support-users.md
+++ b/docs/synvya/support-users.md
@@ -1,0 +1,453 @@
+# Support Users
+
+Spec for letting Synvya support staff create restaurants on behalf of owners and act as any existing restaurant identity for diagnostic/repair work, all from inside the Synvya Restaurant app (`account.synvya.com`).
+
+**System context**:
+- [Architecture Context](architecture-context.md)
+- [Keycast Boundary](specs/keycast-boundary.md)
+- [Restaurant Team E2E](restaurant-team-e2e.md)
+- [Team Invite by Email](team-invite-by-email.md)
+
+---
+
+## 1. Architectural View
+
+### The product problem
+
+Synvya support staff (Maria, et al.) need to onboard restaurants and help fix issues for restaurants that are already onboarded. Today the Restaurant app assumes a 1:1 relationship between a logged-in user and a restaurant: an owner registers, a team is created with the restaurant identity as the team key, the owner is the team's admin. Support staff cannot enter that flow at all — they have no path to (a) provision a restaurant on behalf of an owner who hasn't onboarded yet, or (b) sign as a restaurant they don't own to repair menu data, fix profile fields, etc.
+
+### The architectural choice
+
+Two designs were considered for how the Restaurant app authenticates support actions against Keycast:
+
+1. **Keycast-native** (chosen) — extend Keycast's existing `support_admin` role so support staff can create teams and act as any restaurant team's identity. The Restaurant app talks to Keycast directly, with the support admin's UCAN as authorization. No request-time proxy in `Synvya/server`.
+
+2. **Server-mediated** — add a `support` role to `Synvya/server`'s admin allowlist, have the Restaurant app call new server endpoints, and have the server proxy each support action to Keycast.
+
+Option 1 was chosen because Keycast **already** has a `support_admin` role — Redis-backed, baked into UCANs at login, enforced on 8 existing admin endpoints used by `systemtools` (user lookup, claim tokens, authorization revocation, etc.). The role mechanism, the Redis allowlist, and the audit shape are already in production. Adding two new permission points (team creation + just-in-time team access) inside that existing mechanism is significantly smaller than building a parallel system in `Synvya/server`, and keeps the request-path policy boundary on the resource that owns identity (Keycast).
+
+The `support_admin` role already grants read access to a user's teams and authorizations and the ability to revoke authorizations and issue claim tokens. This spec adds two write-side capabilities: **create new teams** and **just-in-time membership** on existing teams.
+
+### Defining who is a support agent
+
+`systemtools` is the source of truth for who is a Synvya support agent. Keycast's `support_admins` Redis set is a **managed mirror** that the `systemtools` backend keeps in sync — it is never edited by humans directly.
+
+Concretely, `systemtools`' admin user record gains a `support` flag, **orthogonal** to the existing `pulse_only | admin | superadmin` role (a user can have `support: true` independently of any systemtools-UI role). When a `systemtools` `superadmin` toggles the flag on a user, the `systemtools` backend (a) updates its DynamoDB admin table, and (b) calls Keycast `POST /api/admin/support-admins` (or the matching `DELETE` on demotion) to update the Redis mirror. Next time that user logs into Keycast, `is_support_admin()` returns true and the issued UCAN carries `admin_role: "support"`.
+
+For step (b) to authorize against Keycast, the `systemtools` backend signs each call with NIP-98 using a dedicated service identity. Keycast calls pubkeys listed in `ALLOWED_PUBKEYS` **full admins** — operator-level identities with full Keycast authority. The `systemtools` service pubkey is one such full admin, added to the `synvya/{env}/keycast/allowed-pubkeys` secret once at bootstrap. Bootstrap human full admins (Synvya leadership/engineering with direct Keycast authority) are added to the same secret manually and managed by the same secret-update process.
+
+The `systemtools` `superadmin` role does **not** automatically grant Keycast full admin. They are independent: a Synvya leader who needs direct Keycast authority is in `ALLOWED_PUBKEYS` *and* has the systemtools `superadmin` role, by separate operations. This is the deliberate manual-sync boundary.
+
+### What the Restaurant app does after this lands
+
+- A support user logs in to `account.synvya.com` with their normal email/password, no different from a restaurant owner. Keycast issues a UCAN that carries `admin_role: "support"`.
+- The app shows a restaurant picker (UI already exists; the `TeamSelector` component is gated on `teams.length > 1`). For owners with one team, this is a no-op.
+- For support users only, the picker shows a "Create new restaurant" action and a "Open another restaurant" search action.
+- "Create new restaurant" calls Keycast's existing `POST /api/teams` (after the gate change in §3.1). The support user becomes admin of the new team via the existing `create_with_admin` flow and can immediately add the stored key, the authorization, and start populating the restaurant's profile.
+- "Open another restaurant" finds a target via the existing `user-lookup` + `user-teams` admin endpoints, then calls the new `POST /api/admin/teams/:id/support-access` to be added as a member with a fresh authorization. The picker switches active restaurant; signing now happens as that restaurant's identity.
+- On logout, on switching active restaurant, or on session timeout, the app calls `DELETE /api/admin/teams/:id/support-access` to revoke the authorization and remove the support membership.
+
+### What does not change
+
+- Restaurant owner registration, login, claim flow.
+- Existing team admin/member permission model. Owners are still admins of their teams; nothing about that changes.
+- The `TeamSelector` UI for owners who happen to belong to more than one team.
+- `Synvya/server`'s identity, secrets, and the `SERVER_BUNKER_CLIENT_PRIVATE_KEY` it uses to sign on behalf of restaurants. This spec does not touch the always-on signing path. `Synvya/server` is not in the request path for any support action.
+- Existing 8 `is_support_admin` admin endpoints. No regressions.
+- The manual sync between Synvya leadership/engineering pubkeys and Keycast's `ALLOWED_PUBKEYS` secret. Full admin status remains a manually-curated bootstrap list; `systemtools` does not manage it.
+
+### Tenant scoping note
+
+The `support_admins` Redis set is tenant-global (single key, not namespaced by tenant). This is consistent with the current implementation. For Synvya's single-tenant production setup that is correct. If Keycast becomes multi-tenant in a Synvya context, support admins should be re-scoped per tenant; this is called out explicitly in §10.
+
+---
+
+## 2. Scope
+
+### What Keycast owns (new)
+
+- `create_team` gate widening to allow `is_support_admin()` callers.
+- New endpoints for atomic just-in-time support access on existing teams:
+  - `POST /api/admin/teams/:id/support-access` — add the calling support admin as member of the team, mint a fresh `Authorization` against the team's first stored key, return the bunker URL.
+  - `DELETE /api/admin/teams/:id/support-access` — revoke the support admin's active authorizations on the team and remove their membership.
+- A NIP-98 (kind:27235) service-auth path that resolves a request-bound signed envelope to a full-admin context when the signing pubkey is in `ALLOWED_PUBKEYS`. This is what lets the `systemtools` backend write to `support_admins` without needing a human's session cookie.
+- Audit log lines for both new endpoints and the systemtools-mirror operation, mirroring the `revoke_authorization` log pattern.
+
+### What `systemtools` owns (new)
+
+- A `support` flag on the existing admin user record (DynamoDB `synvya-{env}-admin-users`), orthogonal to the existing role enum.
+- A "Support" management surface in the `systemtools` UI (visible to `superadmin` only) that toggles the flag on/off for any existing admin user.
+- A backend mirror that, on each toggle, also calls Keycast `POST /api/admin/support-admins` (or `DELETE`) signed with NIP-98 by the systemtools service identity.
+- A bootstrap configuration: the systemtools service nsec held in AWS Secrets Manager; the corresponding pubkey listed in `synvya/{env}/keycast/allowed-pubkeys`.
+
+### What Keycast does not own
+
+- The Restaurant app's restaurant picker UI, "Create new restaurant" button, and "Open another restaurant" search. Those live in `Synvya/client`.
+- The systemtools-side Support management UI and the DynamoDB `support` flag. Those live in `systemtools` (frontend) and the Synvya server (backend, mirroring to Keycast).
+- The contents of `ALLOWED_PUBKEYS`. The bootstrap manual-sync of Synvya leadership/engineering pubkeys and the systemtools service pubkey is operational, not a Keycast feature.
+
+### What `Synvya/server` does not own
+
+`Synvya/server` is not in the request path for any user-facing support action. The systemtools backend (which today lives inside `Synvya/server`) is in the path only for management operations (toggling the Support flag), not for the support actions themselves. The unused `KEYCAST_SERVICE_TOKEN` in `Synvya/server`'s config remains unused — it is replaced by NIP-98 signing with the systemtools service nsec.
+
+---
+
+## 3. API Changes in Keycast
+
+### 3.1 Widen the `create_team` gate
+
+Today, [`api/src/api/http/teams.rs:68`](../../api/src/api/http/teams.rs):
+
+```rust
+if !super::admin::is_full_admin(&auth) && !can_create_first_team {
+    return Err(ApiError::forbidden(...));
+}
+```
+
+Becomes:
+
+```rust
+if !super::admin::is_full_admin(&auth)
+    && !super::admin::is_support_admin(&auth).await
+    && !can_create_first_team
+{
+    return Err(ApiError::forbidden(...));
+}
+```
+
+The existing `create_with_admin` repository call ([`core/src/repositories/team.rs:351`](../../core/src/repositories/team.rs)) inserts the caller as the team's `admin`, so a support user who creates a team gets full admin privileges on that team and can then call `add_key`, `add_authorization`, `add_user`, `invite_user`, etc. without further changes.
+
+### 3.2 New endpoint: `POST /api/admin/teams/:id/support-access`
+
+**Auth**: `is_support_admin()` only. Tenant-scoped via `TenantExtractor`.
+
+**Path params**: `id` — team id.
+
+**Request body**:
+```json
+{
+  "policy_id": 42,           // optional; defaults to the team's "All Access" policy
+  "label": "support: maria"  // optional; recorded on the authorization for audit clarity
+}
+```
+
+**Behavior** (single transaction):
+1. Look up the team and verify it belongs to the caller's tenant.
+2. If the caller is not yet a `team_users` row for this team, insert one with `role = 'member'`. If the caller is already a member, leave the row alone (do not downgrade an admin).
+3. Pick the team's first non-revoked stored key (this is the restaurant identity; teams have exactly one in the current Synvya model).
+4. Mint a fresh `Authorization` against that stored key, with `connected_client_pubkey = caller`, derived bunker keys, and a fresh connection secret. Use the existing `auth_repo.create()` path so the signer daemon picks it up.
+5. Return the bunker URL plus the authorization summary.
+
+**Response**:
+```json
+{
+  "team_id": 17,
+  "stored_key_pubkey": "abcd...",
+  "authorization": { /* AuthorizationCreatedResponse fields */ },
+  "bunker_url": "bunker://..."
+}
+```
+
+**Audit**: `tracing::info!("Support access granted: team={team_id} support_admin={pubkey} authorization={auth_id}")`.
+
+### 3.3 New endpoint: `DELETE /api/admin/teams/:id/support-access`
+
+**Auth**: `is_support_admin()` only. Tenant-scoped.
+
+**Behavior** (single transaction):
+1. Find all non-revoked authorizations on this team where `connected_client_pubkey = caller`. Set `revoked_at = NOW()` and `revoked_reason = 'support_session_end'` on each. Notify the signer daemon (`AuthorizationCommand::Remove`) for each one, mirroring [`admin.rs:1138`](../../api/src/api/http/admin.rs).
+2. If the caller's `team_users` row has `role = 'member'` (not `admin`), remove it. If they are an `admin` of this team (e.g., they created it), leave the membership alone.
+3. Return a count of revoked authorizations and a `removed_membership: bool`.
+
+**Response**:
+```json
+{
+  "team_id": 17,
+  "revoked_authorizations": 1,
+  "removed_membership": true
+}
+```
+
+**Audit**: `tracing::info!("Support access released: team={team_id} support_admin={pubkey} revoked={count}")`.
+
+### 3.4 Route registration
+
+Both new routes are registered alongside the existing admin block at [`api/src/api/http/routes.rs:182`](../../api/src/api/http/routes.rs) under the `auth_cors` layer:
+
+```rust
+.route(
+    "/admin/teams/:id/support-access",
+    post(admin::grant_team_support_access)
+        .delete(admin::release_team_support_access),
+)
+```
+
+### 3.5 NIP-98 service-auth path on admin routes
+
+Keycast already verifies kind:27235 (NIP-98) envelopes during NIP-98 login at [`api/src/api/http/auth.rs:559`](../../api/src/api/http/auth.rs) and stamps `admin_role: "full" | "support"` into the issued UCAN. This spec extends the same primitive to **any admin route**, not just login:
+
+- A request carrying `Authorization: Nostr <base64(kind:27235 event)>` is verified the same way (signature valid, `u` tag matches request URL, `method` tag matches HTTP method, `created_at` within tolerance).
+- If the signing pubkey is in `ALLOWED_PUBKEYS`, the request is treated as if it carried a full-admin UCAN. `is_full_admin()` returns true for that request.
+- If the signing pubkey is in the `support_admins` Redis set, the request is treated as `admin_role: "support"`.
+- Otherwise the envelope is rejected.
+
+This middleware is the entry point the `systemtools` backend uses when it calls `POST /api/admin/support-admins`: the call is signed with the systemtools service nsec, and Keycast resolves the service pubkey to full-admin authority via this path. No session cookie, no shared secret token. Each request is independently authenticated by signature.
+
+Keep the existing UCAN cookie path untouched — it remains the primary auth mechanism for human callers (Restaurant app, future systemtools UI calls that piggyback on a user's keycast session). NIP-98 service-auth is an additional path, not a replacement.
+
+The middleware lives in `api/src/api/extractors.rs` (or a new file `api/src/api/nip98_extractor.rs`) and is composed into the same `UcanAuth` extractor so handlers do not need to know which path the request came in on.
+
+---
+
+## 4. Reused Surface (no changes)
+
+The following are already implemented and gated on `is_support_admin()` ([`api/src/api/http/admin.rs`](../../api/src/api/http/admin.rs)). The Restaurant app will call them as-is:
+
+| Endpoint | Use in support flow |
+|---|---|
+| `GET /api/admin/status` | After login, the client reads `role: "support"` to decide whether to show support UI |
+| `GET /api/admin/user-lookup?q=` | Find a target user (restaurant owner) by email/username/pubkey |
+| `GET /api/admin/user-teams?pubkey=` | List a target user's restaurants and their authorizations |
+| `POST /api/admin/authorizations/:id/revoke` | Manual revoke for diagnostics; complements the bulk revoke in `DELETE .../support-access` |
+| `GET /api/admin/claim-tokens?pubkey=` | Look up a pending claim token for handoff |
+| `POST /api/admin/claim-tokens` | Generate a claim link to hand off the new restaurant to its owner |
+| `POST /api/admin/support-admins` | Full-admin only. Called by the `systemtools` backend (NIP-98-signed by the systemtools service identity) when a `superadmin` toggles the Support flag on a user. Not called by humans directly in Phase 2. |
+| `DELETE /api/admin/support-admins/:pubkey` | Full-admin only. Same caller as above; invoked on demotion. |
+
+For team-internal operations after `create_team` (adding a stored key, creating the first server-side authorization for `Synvya/server`, inviting the actual owner by email), the support user uses the existing team-admin endpoints by virtue of being the team's admin. Specifically:
+
+- `POST /api/teams/:id/keys` — add the restaurant's stored key.
+- `POST /api/teams/:id/keys/:pubkey/authorizations` — mint the authorization the support user (or `Synvya/server`) will use for signing.
+- `POST /api/teams/:id/invitations` — email the actual restaurant owner an invite to take over as admin.
+
+---
+
+## 5. Lifecycle
+
+### 5.1 Provision a new restaurant (cold start)
+
+```
+Maria (support_admin)                    Restaurant app                   Keycast
+  │                                            │                              │
+  │─ login email/password ────────────────────►│                              │
+  │                                            │─ POST /api/auth/login ──────►│
+  │                                            │◄ UCAN { admin_role: support }│
+  │                                            │                              │
+  │                                            │─ GET /api/admin/status ─────►│
+  │                                            │◄ { role: "support" }         │
+  │                                            │                              │
+  │   (picker shows "Create new restaurant")   │                              │
+  │─ click ──────────────────────────────────►│                              │
+  │   { name: "Joe's Diner" }                  │                              │
+  │                                            │─ POST /api/teams ───────────►│
+  │                                            │◄ team_id, Maria=admin        │
+  │                                            │─ POST /teams/:id/keys ──────►│
+  │                                            │◄ stored_key (restaurant id)  │
+  │                                            │─ POST /authorizations ──────►│
+  │                                            │◄ bunker_url                  │
+  │                                            │   (connect bunker, sign as   │
+  │                                            │    restaurant from now on)   │
+  │ ... populate menu, profile, hours ...      │                              │
+  │                                            │                              │
+  │─ click "Hand off to owner" ───────────────►│                              │
+  │   { owner_email: joe@... }                 │                              │
+  │                                            │─ POST /teams/:id/invitations►│
+  │                                            │◄ invitation sent             │
+  │                                            │                              │
+  │   (later: Joe accepts, becomes admin)      │                              │
+  │   (later: Maria switches away, calls       │                              │
+  │    DELETE /support-access — see 5.3)       │                              │
+```
+
+### 5.2 Open an existing restaurant for diagnostics
+
+```
+Maria                       Restaurant app                   Keycast
+  │                              │                              │
+  │─ search "Joe's Diner" ──────►│                              │
+  │                              │─ GET /admin/user-lookup ────►│
+  │                              │◄ candidates                  │
+  │ pick a candidate user        │                              │
+  │                              │─ GET /admin/user-teams ─────►│
+  │                              │◄ teams + authorizations      │
+  │ pick a team                  │                              │
+  │                              │─ POST /admin/teams/:id/      │
+  │                              │       support-access ───────►│
+  │                              │◄ bunker_url                  │
+  │                              │   (disconnect previous       │
+  │                              │    bunker, connect to new,   │
+  │                              │    active team = this one)   │
+  │ ... fix the issue ...        │                              │
+```
+
+### 5.3 Release access (logout, switch, or timeout)
+
+```
+Restaurant app                                                  Keycast
+      │                                                            │
+      │─ DELETE /api/admin/teams/:id/support-access ──────────────►│
+      │   (revokes Maria's active authorizations on this team,     │
+      │    removes membership row if she was a `member`)           │
+      │◄ { revoked_authorizations: 1, removed_membership: true }   │
+```
+
+The signer daemon receives `AuthorizationCommand::Remove` for each revoked authorization and drops the in-memory handler, so any subsequent NIP-46 traffic from Maria's bunker URL fails immediately. The audit log records both bookends (grant and release) with Maria's pubkey.
+
+---
+
+## 6. Restaurant Client Changes (`Synvya/client`)
+
+Out-of-scope for this Keycast spec but listed for the cross-repo summary:
+
+- After login, call `GET /api/admin/status`. If `role === "support"`, expose support UI.
+- Replace the implicit "land on `/app/profile`" behavior with a restaurant picker when `role === "support"`. For `role === null` users (regular owners), keep current behavior.
+- Picker shows current memberships from `listTeams()`, plus a "Create new restaurant" button and an "Open another restaurant" search.
+- "Open another restaurant" → search via `user-lookup`/`user-teams` → pick a team → call `POST /api/admin/teams/:id/support-access` → connect the returned bunker URL.
+- On active-team switch, logout, or session timeout, call `DELETE /api/admin/teams/:id/support-access` for the previous active team if it was a support session (i.e., not a team Maria is a permanent member or admin of).
+- For provisioning (`POST /api/teams`), the existing `keycastClient.createTeam(...)` continues to work because the gate is widened, not replaced. No new client method needed for creation.
+
+The `TeamSelector` component already supports the multi-team case; it renders only when `teams.length > 1`. The picker shell wraps it for the support flow.
+
+---
+
+## 7. Audit and Observability
+
+Every support write operation emits a structured `tracing::info!` line with the support admin's pubkey, the target team, and the operation outcome. This mirrors the existing `revoke_authorization` log pattern at [`api/src/api/http/admin.rs:1154`](../../api/src/api/http/admin.rs).
+
+Log lines added or relied upon:
+
+- `Team created by support admin: team_id={team_id} support_admin={pubkey} name={name}` — emit from `create_team` when the gate path is `is_support_admin`.
+- `Support access granted: team={team_id} support_admin={pubkey} authorization={auth_id}` — emit from `grant_team_support_access`.
+- `Support access released: team={team_id} support_admin={pubkey} revoked={count}` — emit from `release_team_support_access`.
+- Existing `Authorization {} revoked by admin {}` continues to fire for each individual revocation inside the release endpoint.
+
+No structured audit table is added in this spec; the structured log lines feed Cloud Logging and are sufficient for the current support volume. A formal audit table is left to a future spec when volume justifies it.
+
+---
+
+## 8. Security Considerations
+
+1. **Privilege scope**. A support admin gains write access to any team in the tenant via `support-access`, including teams where the actual owner is an admin. This is intentional — that is the support capability — but it must be paired with two operational controls: (a) `add_support_admin` is gated to full admins only, and (b) every grant/release is logged with the support admin's pubkey.
+
+2. **JIT membership leak**. If `release_team_support_access` is never called (browser crashes, network failure, the support admin closes their laptop without logging out), the support admin remains a member with a live authorization until either (a) the authorization expires or (b) another support admin manually revokes via `revoke_authorization`. To bound this, support-issued authorizations are minted with a short `expires_at` (default 24h, configurable per call). The signer daemon enforces expiry.
+
+3. **Restaurant owner visibility**. After this lands, a restaurant owner viewing their team membership list will see support admins listed alongside the owner during active support sessions. This is a feature, not a leak, but the Restaurant app should label support members distinctly so owners are not confused about who has access. The label is applied client-side based on `team_users.role = 'member'` plus a presence check against the `support_admins` set (read via `GET /api/admin/support-admins` if owner has visibility, or returned inline by `user-teams` for support; this is a client UX decision and out of scope for Keycast).
+
+4. **Audit trail tampering**. Support admins cannot delete or amend their own log lines; logs go to Cloud Logging via the standard request path.
+
+5. **Stored key access**. Support admins never touch the restaurant's stored secret key directly. They sign via NIP-46 against an authorization they hold, exactly like any other team member. The encryption-at-rest model is unchanged.
+
+6. **Systemtools service identity**. The systemtools service nsec is a full-admin credential — anyone holding it can do anything in Keycast. It must be stored only in AWS Secrets Manager, never logged, never passed through frontend code, and never used outside the systemtools backend. Compromise of this nsec is equivalent to compromise of a Keycast root credential and is handled by rotating the value in Secrets Manager and updating `synvya/{env}/keycast/allowed-pubkeys`.
+
+7. **Demotion is eventually consistent**. When a `superadmin` removes the Support flag from a user, the user's UCAN may still carry `admin_role: "support"` until it expires (UCANs are stamped at login, not re-checked on every request). For immediate revocation, the systemtools backend should also revoke the user's active Keycast sessions via existing session-management endpoints, or accept that Support powers persist until UCAN expiry. The current Keycast UCAN TTL is short enough (minutes) that this is acceptable for normal demotions; emergency demotions (terminated employees) require explicit session revocation.
+
+---
+
+## 9. Implementation Checklist
+
+Keycast (`synvya-staging` branch):
+
+- [ ] Widen `create_team` gate at [`api/src/api/http/teams.rs:68`](../../api/src/api/http/teams.rs) to call `is_support_admin().await`.
+- [ ] Add `grant_team_support_access` handler in [`api/src/api/http/admin.rs`](../../api/src/api/http/admin.rs).
+- [ ] Add `release_team_support_access` handler in the same file.
+- [ ] Register both routes under `/admin/teams/:id/support-access` in [`api/src/api/http/routes.rs`](../../api/src/api/http/routes.rs).
+- [ ] Add NIP-98 service-auth extractor (§3.5) and compose it into `UcanAuth` so any admin route accepts either a UCAN cookie or a request-bound NIP-98 envelope.
+- [ ] Add structured log lines per §7.
+- [ ] Default authorization expiry of 24h on support-issued authorizations (per §8.2). Make configurable via request body.
+- [ ] Tests:
+  - [ ] support admin can create a team; non-admin non-support user with one existing team membership cannot.
+  - [ ] support admin can grant + release access on a team they are not a member of; second release is a no-op.
+  - [ ] release does not remove `admin` membership (e.g., the support user who originally created the team).
+  - [ ] release notifies the signer daemon (`AuthorizationCommand::Remove`).
+  - [ ] full admin retains all current capabilities.
+  - [ ] non-support, non-admin caller is forbidden on both new endpoints.
+  - [ ] NIP-98-signed call from a pubkey in `ALLOWED_PUBKEYS` resolves to full-admin and can `POST /api/admin/support-admins`.
+  - [ ] NIP-98-signed call from a pubkey not in `ALLOWED_PUBKEYS` and not in `support_admins` is rejected.
+  - [ ] NIP-98 envelope with mismatched `u` tag, mismatched `method` tag, or stale `created_at` is rejected.
+
+Restaurant app (`Synvya/client`, separate PR):
+
+- [ ] Read `role` from `GET /api/admin/status` on auth init.
+- [ ] Picker shell with "Create new restaurant" and "Open another restaurant" actions when `role === "support"`.
+- [ ] Wire "Open another restaurant" to `user-lookup` → `user-teams` → `support-access`.
+- [ ] On active-team switch / logout, call `DELETE .../support-access` if the leaving team was a support session.
+- [ ] Distinct UI label for support members on the Team page.
+
+`systemtools` and Synvya server backend (separate PR):
+
+- [ ] Add `support: boolean` attribute to `synvya-{env}-admin-users` DynamoDB items (default false on existing rows).
+- [ ] Add `support` to the `AdminUser` TypeScript type and the `SessionInfo` shape returned by `GET /api/admin/me`.
+- [ ] Render a "Support" toggle in the systemtools admin user management page (already a Phase 4 placeholder), gated on `superadmin` role.
+- [ ] Backend handler for the toggle: write DynamoDB, then call Keycast `POST /api/admin/support-admins` (or `DELETE /api/admin/support-admins/:pubkey` on demotion) with NIP-98 signing.
+- [ ] `KeycastAdminClient` service (~150 LOC): holds the systemtools service nsec from AWS Secrets Manager; signs each call with NIP-98 (URL + method + timestamp tags); retries with exponential backoff on transient errors.
+- [ ] Idempotency: if the DynamoDB write succeeds but the Keycast mirror call fails, the toggle is marked "drift" and a sweeper job reconciles. Drift is also surfaced in the admin UI as a warning.
+- [ ] Tests: end-to-end toggle promotes/demotes the user in both DynamoDB and Keycast Redis; failure of the Keycast call is captured as drift; idempotent re-toggle is a no-op.
+
+Operations:
+
+- [ ] Generate the systemtools service nsec; store as `synvya/{env}/systemtools/keycast-service-key` in AWS Secrets Manager.
+- [ ] Add the corresponding pubkey to `synvya/{env}/keycast/allowed-pubkeys` alongside the existing bootstrap pubkeys.
+- [ ] Document the manual sync runbook for adding/removing Synvya leadership/engineering pubkeys to/from `allowed-pubkeys`.
+
+---
+
+## 10. Out of Scope / Future Work
+
+- **Tenant-scoped support admins**. Today the `support_admins` Redis set is keyed `support_admins` (single key). If Keycast becomes multi-tenant in Synvya, the set should be namespaced per tenant (`support_admins:{tenant_id}`) and `is_support_admin` should consult the caller's tenant. Not needed yet.
+- **Automatic ALLOWED_PUBKEYS sync**. Bootstrap full-admin membership is intentionally manual. Removing this manual step would either require systemtools to manage `ALLOWED_PUBKEYS` (which would mean systemtools could elevate itself or any of its users to Keycast full admin — a much larger blast radius than the Support flag), or a separate identity system. Both are larger than the problem currently warrants.
+- **Auto-expire of stale support sessions**. Beyond the 24h authorization expiry, a periodic sweeper that revokes any `support` authorizations older than N hours would reduce the leak surface in §8.2. Defer until we see real volume.
+- **Read-only support mode**. A support admin could be granted "view this team's data" without minting a signing authorization. Not in this spec — current Synvya support tasks are write-leaning (fix bad menu data, repair profile fields).
+- **Formal audit table**. Once support volume justifies it, move from `tracing::info!` to a structured `admin_audit_log` table with `(actor_pubkey, action, target_team_id, target_authorization_id, outcome, ts, request_id)` columns.
+- **Support team identity**. Synvya may eventually want a "Synvya Support" Nostr identity that signs outbound communications. That is a separate decision unrelated to this spec; the same way `systemtools` chose against a shared admin team identity, this spec does not introduce one. Each support action carries the acting admin's personal pubkey.
+
+---
+
+## 11. Operational: Defining Support Agents
+
+This section is the runbook for the management surface introduced in §1 ("Defining who is a support agent") and §2 ("What `systemtools` owns").
+
+### Roles in play
+
+| Role | Where defined | Manages | Bootstrap |
+|---|---|---|---|
+| **Keycast full admin** | Pubkey listed in `ALLOWED_PUBKEYS` env var, sourced from `synvya/{env}/keycast/allowed-pubkeys` secret | Direct full Keycast authority; can promote/demote support admins, run admin scripts, read/write any team | **Manual.** Edit the secret, redeploy/refresh. |
+| **Keycast support admin** | Pubkey in Redis `support_admins` set | Acts as any restaurant identity in the tenant; creates new restaurant teams; uses `is_support_admin`-gated read/write endpoints | **Automatic** via systemtools mirror (see below). |
+| **`systemtools` `superadmin`** | DynamoDB row in `synvya-{env}-admin-users` with `role: 'superadmin'` | Manages `systemtools` admin users, including toggling the Support flag | **Manual.** Existing systemtools admin management. Independent of Keycast full admin. |
+| **`systemtools` Support flag** | DynamoDB row with `support: true` | When toggled, drives the Keycast support-admins mirror call | Toggled by a `systemtools` `superadmin` in the systemtools UI. |
+
+A single Synvya employee can hold any combination: e.g., an engineer might be a Keycast full admin (in `ALLOWED_PUBKEYS`) *and* a systemtools `superadmin` *and* have the Support flag, while a customer-facing agent might only have the Support flag (with role `pulse_only` or `admin` to retain systemtools UI access for their day job).
+
+### Promotion flow (toggle Support flag on)
+
+1. Synvya `superadmin` opens the `systemtools` admin user page for the target user.
+2. Toggles the **Support** checkbox to on.
+3. `systemtools` backend writes `support: true` to the DynamoDB row.
+4. `systemtools` backend builds a kind:27235 NIP-98 envelope: `u` = `https://auth.synvya.com/api/admin/support-admins`, `method` = `POST`, signed with the systemtools service nsec.
+5. `systemtools` backend sends `POST /api/admin/support-admins` to Keycast with `Authorization: Nostr <base64(envelope)>` and body `{ "identifier": "<target user's pubkey or email>" }`.
+6. Keycast verifies the envelope, resolves the systemtools service pubkey to full-admin via `ALLOWED_PUBKEYS`, runs the existing `add_support_admin` handler, and writes to Redis.
+7. Next time the target user logs into Keycast, `is_support_admin()` returns true and their UCAN carries `admin_role: "support"`.
+
+### Demotion flow (toggle Support flag off)
+
+Symmetric to promotion: DynamoDB write, then `DELETE /api/admin/support-admins/:pubkey` with NIP-98 signing. The Redis set membership is removed. Existing user UCANs may still carry the `support` role until they expire — see §8.7 for the eventual-consistency note.
+
+### Bootstrap (one-time, per environment)
+
+Run once when standing up a new staging or production environment, or when rotating credentials:
+
+1. Generate a fresh nsec for the systemtools service identity.
+2. Store as `synvya/{env}/systemtools/keycast-service-key` in AWS Secrets Manager.
+3. Compute the corresponding hex pubkey.
+4. Edit `synvya/{env}/keycast/allowed-pubkeys` to append the systemtools service pubkey alongside the existing bootstrap human pubkeys.
+5. Redeploy or trigger the secret-refresh path on Keycast so the new `ALLOWED_PUBKEYS` is loaded.
+6. Verify by issuing a test NIP-98-signed `GET /api/admin/support-admins` from the systemtools backend and confirming a `200` response.
+
+### Adding or removing a Synvya leadership/engineering full admin
+
+This is **manual** by design (§10). Steps:
+
+1. Edit `synvya/{env}/keycast/allowed-pubkeys` to add or remove the human's hex pubkey.
+2. Redeploy or trigger secret refresh on Keycast.
+3. The change takes effect on the next request that re-reads `ALLOWED_PUBKEYS`. Existing UCANs already issued to that pubkey carry the role until they expire.
+
+There is no UI for this. It is a deliberate, low-frequency operation tied to the secret-management workflow.

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -808,9 +808,7 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
                     let redirect_url = redirect_url_for_fallback.clone();
                     async move {
                         match redirect_url {
-                            Some(url) => {
-                                axum::response::Redirect::temporary(&url).into_response()
-                            }
+                            Some(url) => axum::response::Redirect::temporary(&url).into_response(),
                             None => (StatusCode::NOT_FOUND, "Not found").into_response(),
                         }
                     }

--- a/keycast/src/main.rs
+++ b/keycast/src/main.rs
@@ -774,22 +774,48 @@ async fn async_main(worker_threads: usize) -> Result<(), Box<dyn std::error::Err
             }
         };
 
-        let app = app.route("/verify-email", axum::routing::get(verify_email_handler));
+        // SvelteKit entry points must redirect, not serve the SPA. Without
+        // explicit routes, the ServeDir fallback below would expose the login
+        // page anyway: `/` resolves to `index.html` via
+        // `append_index_html_on_directories`, and `/index.html` is a real file
+        // in the build output.
+        let redirect_url_for_routes = redirect_url.clone();
+        let redirect_handler = axum::routing::get(move || {
+            let redirect_url = redirect_url_for_routes.clone();
+            async move {
+                match redirect_url {
+                    Some(url) => axum::response::Redirect::temporary(&url).into_response(),
+                    None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+                }
+            }
+        });
+
+        let app = app
+            .route("/", redirect_handler.clone())
+            .route("/index.html", redirect_handler)
+            .route("/verify-email", axum::routing::get(verify_email_handler));
 
         // Serve SvelteKit static assets (/_app/*, favicon, logos) needed by the
-        // verify-email page; unmatched routes redirect to WEB_UI_REDIRECT_URL.
+        // verify-email page. Unmatched routes redirect to WEB_UI_REDIRECT_URL.
+        // `append_index_html_on_directories(false)` prevents ServeDir from
+        // silently serving build/index.html for any directory-style request
+        // beyond `/` (which is already routed explicitly above).
         let redirect_url_for_fallback = redirect_url.clone();
-        app.fallback_service(ServeDir::new(&web_build_dir).fallback(axum::routing::any(
-            move || {
-                let redirect_url = redirect_url_for_fallback.clone();
-                async move {
-                    match redirect_url {
-                        Some(url) => axum::response::Redirect::temporary(&url).into_response(),
-                        None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+        app.fallback_service(
+            ServeDir::new(&web_build_dir)
+                .append_index_html_on_directories(false)
+                .fallback(axum::routing::any(move || {
+                    let redirect_url = redirect_url_for_fallback.clone();
+                    async move {
+                        match redirect_url {
+                            Some(url) => {
+                                axum::response::Redirect::temporary(&url).into_response()
+                            }
+                            None => (StatusCode::NOT_FOUND, "Not found").into_response(),
+                        }
                     }
-                }
-            },
-        )))
+                })),
+        )
     } else {
         // SvelteKit frontend - explicitly handle root and index.html with injection
         // This ensures index.html always goes through injection, not served as static file

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -29,7 +29,7 @@ else
     exit 1
 fi
 
-EXTRA_ALLOWED_ORIGINS="https://account.synvya.com,https://account.staging.synvya.com,https://server.synvya.com,https://server.staging.synvya.com"
+EXTRA_ALLOWED_ORIGINS="https://account.synvya.com,https://account.staging.synvya.com,https://server.synvya.com,https://server.staging.synvya.com,https://admin.synvya.com,https://admin.staging.synvya.com"
 ALLOWED_PUBKEYS=$(get_secret synvya/$ENV/keycast/allowed-pubkeys 2>/dev/null || echo "")
 
 cat > /opt/synvya/.env <<EOF

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -19,11 +19,13 @@ if [ "$ENV" = "staging" ]; then
     KMS_KEY_ID=alias/keycast-master-key
     INVITE_BASE_URL=https://account.staging.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.staging.synvya.com
+    ADMIN_BASE_URL=https://admin.staging.synvya.com
 elif [ "$ENV" = "production" ]; then
     DOMAIN=auth.synvya.com
     KMS_KEY_ID=alias/synvya-production-keycast-masterkey
     INVITE_BASE_URL=https://account.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.synvya.com
+    ADMIN_BASE_URL=https://admin.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1
@@ -46,6 +48,7 @@ BASE_URL=https://$DOMAIN
 APP_URL=https://$DOMAIN
 INVITE_BASE_URL=$INVITE_BASE_URL
 PASSWORD_RESET_BASE_URL=$PASSWORD_RESET_BASE_URL
+ADMIN_BASE_URL=$ADMIN_BASE_URL
 VITE_DOMAIN=https://$DOMAIN
 FROM_EMAIL=noreply@synvya.com
 FROM_NAME=Synvya

--- a/web/src/routes/verify-email/+page.svelte
+++ b/web/src/routes/verify-email/+page.svelte
@@ -11,7 +11,7 @@
 	const api = new KeycastApi();
 	const loginUrl = getLoginUrl();
 	const isSynvyaManaged = loginUrl !== '/login';
-	const pageTitle = isSynvyaManaged ? 'Verify Email - Synvya' : `Verify Email - ${BRAND.name}`;
+	const pageTitle = isSynvyaManaged ? 'Verify Email - Synvya Restaurant' : `Verify Email - ${BRAND.name}`;
 	let status = $state<'loading' | 'processing' | 'success' | 'oauth_redirect' | 'headless_verified' | 'error' | 'no-token'>('loading');
 	let message = $state('');
 	let redirectUrl = $state('');
@@ -236,7 +236,17 @@
 	}
 
 	.synvya-page {
-		background: color-mix(in srgb, var(--color-divine-muted) 60%, white);
+		position: fixed;
+		inset: 0;
+		z-index: 1;
+		background: hsl(0 0% 100%);
+		overflow-y: auto;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.synvya-page {
+			background: hsl(222.2 84% 4.9%);
+		}
 	}
 
 	.verify-container {
@@ -338,10 +348,17 @@
 	}
 
 	.synvya-container h1 {
-		color: #0f172a;
+		color: hsl(222.2 84% 4.9%);
+		font-family: system-ui, -apple-system, sans-serif;
 		font-size: 1.25rem;
 		font-weight: 600;
 		letter-spacing: -0.01em;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.synvya-container h1 {
+			color: hsl(210 40% 98%);
+		}
 	}
 
 	.subtitle {
@@ -353,7 +370,15 @@
 	.synvya-container .subtitle,
 	.synvya-container .redirect-notice,
 	.synvya-container .processing-notice {
-		color: #475569;
+		color: hsl(215.4 16.3% 46.9%);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.synvya-container .subtitle,
+		.synvya-container .redirect-notice,
+		.synvya-container .processing-notice {
+			color: hsl(215 20.2% 65.1%);
+		}
 	}
 
 	/* Synvya-themed status icons: small chip with soft background instead of
@@ -379,8 +404,27 @@
 	}
 
 	.synvya-container .status-icon.loading :global(svg) {
-		color: #0f172a;
+		color: hsl(222.2 84% 4.9%);
 		background: rgba(15, 23, 42, 0.04);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.synvya-container .status-icon :global(svg) {
+			background: rgba(255, 255, 255, 0.06);
+		}
+
+		.synvya-container .status-icon.success :global(svg) {
+			background: rgba(22, 163, 74, 0.15);
+		}
+
+		.synvya-container .status-icon.error :global(svg) {
+			background: rgba(220, 38, 38, 0.12);
+		}
+
+		.synvya-container .status-icon.loading :global(svg) {
+			color: hsl(210 40% 98%);
+			background: rgba(255, 255, 255, 0.06);
+		}
 	}
 
 	.synvya-container .status-icon :global(.synvya-spin) {
@@ -420,8 +464,8 @@
 	}
 
 	.synvya-container .btn-primary {
-		background: #0f172a;
-		box-shadow: none;
+		background: hsl(142.1 76.2% 36.3%);
+		border-radius: 0.375rem;
 	}
 
 	.btn-primary:hover {
@@ -430,7 +474,7 @@
 	}
 
 	.synvya-container .btn-primary:hover {
-		background: #111827;
+		background: hsl(142.1 76.2% 30%);
 	}
 
 	.btn-secondary {
@@ -448,9 +492,10 @@
 	}
 
 	.synvya-container .btn-secondary {
-		background: rgba(255, 255, 255, 0.72);
-		border-color: rgba(15, 23, 42, 0.12);
-		color: #0f172a;
+		background: transparent;
+		border-color: hsl(214.3 31.8% 91.4%);
+		border-radius: 0.375rem;
+		color: hsl(222.2 84% 4.9%);
 	}
 
 	.btn-secondary:hover {
@@ -459,7 +504,19 @@
 	}
 
 	.synvya-container .btn-secondary:hover {
-		background: rgba(248, 250, 252, 1);
-		border-color: rgba(15, 23, 42, 0.2);
+		background: hsl(210 40% 96.1%);
+		border-color: hsl(214.3 31.8% 83%);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.synvya-container .btn-secondary {
+			border-color: rgba(255, 255, 255, 0.12);
+			color: hsl(210 40% 98%);
+		}
+
+		.synvya-container .btn-secondary:hover {
+			background: rgba(255, 255, 255, 0.06);
+			border-color: rgba(255, 255, 255, 0.2);
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- NIP-98 service auth for admin routes
- Support-user endpoints (JIT team membership, `is_support_member` enrichment)
- Admin team-lookup endpoint (`GET /api/admin/team-lookup`)
- Claim form improvements (email prefill, Synvya branding)
- DISABLE_WEB_UI fix + verify-email branding
- Test coverage for admin support access and team lookup
- New docs (support-users, service-auth, admin-user-provisioning)

## Files changed
25 files changed, ~2,582 additions, ~165 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)