### PR TITLE
Configure per-environment Nostr relay URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ ALLOWED_ORIGINS=https://keycast.example.com,https://peek.verse.app,https://*.ope
 # No default - must be explicitly set to prevent unintended external connections
 # The signer connects to these relays for NIP-46 communication
 # All bunker URLs will reference these relays (deployment-wide setting)
-BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol
+BUNKER_RELAYS=wss://relay.local.synvya.com
 
 # Optional: SendGrid API key for email sending (if not set, emails will be logged to console)
 SENDGRID_API_KEY=
@@ -90,9 +90,9 @@ VITE_ALLOWED_PUBKEYS=
 # NDK explicit relay URLs for reading/subscribing to Nostr events (comma-separated WebSocket URLs)
 # If not set, NDK will not connect to any external relays (no external connections)
 # Example: wss://relay.divine.video,wss://purplepag.es,wss://relay.nostr.band
-VITE_NDK_EXPLICIT_RELAYS=wss://relay.divine.video,wss://purplepag.es,wss://relay.nostr.band,wss://relay.snort.social,wss://relay.primal.net
+VITE_NDK_EXPLICIT_RELAYS=wss://relay.local.synvya.com
 
 # NDK bunker relay URLs for NIP-46 bunker communication (comma-separated WebSocket URLs)
 # If not set, bunker NDK will not connect to any external relays
 # Example: wss://relay.divine.video,wss://relay.primal.net
-VITE_NDK_BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol
+VITE_NDK_BUNKER_RELAYS=wss://relay.local.synvya.com

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -20,12 +20,18 @@ if [ "$ENV" = "staging" ]; then
     INVITE_BASE_URL=https://account.staging.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.staging.synvya.com
     ADMIN_BASE_URL=https://admin.staging.synvya.com
+    BUNKER_RELAYS=wss://relay.staging.synvya.com
+    VITE_NDK_EXPLICIT_RELAYS=wss://relay.staging.synvya.com
+    VITE_NDK_BUNKER_RELAYS=wss://relay.staging.synvya.com
 elif [ "$ENV" = "production" ]; then
     DOMAIN=auth.synvya.com
     KMS_KEY_ID=alias/synvya-production-keycast-masterkey
     INVITE_BASE_URL=https://account.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.synvya.com
     ADMIN_BASE_URL=https://admin.synvya.com
+    BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
+    VITE_NDK_EXPLICIT_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
+    VITE_NDK_BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1
@@ -42,7 +48,9 @@ POSTGRES_PASSWORD=$(get_secret synvya/$ENV/keycast/postgres-password)
 SERVER_NSEC=$(get_secret synvya/$ENV/keycast/privatekey)
 AWS_KMS_KEY_ID=$KMS_KEY_ID
 AWS_REGION=$REGION
-BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social
+BUNKER_RELAYS=$BUNKER_RELAYS
+VITE_NDK_EXPLICIT_RELAYS=$VITE_NDK_EXPLICIT_RELAYS
+VITE_NDK_BUNKER_RELAYS=$VITE_NDK_BUNKER_RELAYS
 ALLOWED_ORIGINS=https://$DOMAIN,$EXTRA_ALLOWED_ORIGINS
 BASE_URL=https://$DOMAIN
 APP_URL=https://$DOMAIN


### PR DESCRIPTION
## Summary
- Move `BUNKER_RELAYS` into per-environment blocks in `load-secrets.sh` (staging vs production)
- Add `VITE_NDK_EXPLICIT_RELAYS` and `VITE_NDK_BUNKER_RELAYS` alongside `BUNKER_RELAYS`
- Update `.env.example` relay defaults for local Synvya dev (`wss://relay.local.synvya.com`)

## Test plan
- [ ] Deploy to staging: verify signer daemon logs show connection to `relay.staging.synvya.com`
- [ ] Verify bunker URLs returned by `/api/user/bunker` reference the staging relay

🤖 Generated with [Claude Code](https://claude.ai/claude-code)