### PR TITLE
Use only wss://relay.synvya.com for production

### DIFF
--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -29,9 +29,9 @@ elif [ "$ENV" = "production" ]; then
     INVITE_BASE_URL=https://account.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.synvya.com
     ADMIN_BASE_URL=https://admin.synvya.com
-    BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
-    VITE_NDK_EXPLICIT_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
-    VITE_NDK_BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
+    BUNKER_RELAYS=wss://relay.synvya.com
+    VITE_NDK_EXPLICIT_RELAYS=wss://relay.synvya.com
+    VITE_NDK_BUNKER_RELAYS=wss://relay.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1


### PR DESCRIPTION
## Summary
- Update production relay config in `load-secrets.sh` to use only `wss://relay.synvya.com` (removes `relay.damus.io` and `nos.lol`)

## Test plan
- [ ] Deploy to production: verify signer daemon logs show connection to `relay.synvya.com` only

🤖 Generated with [Claude Code](https://claude.ai/claude-code)