### PR TITLE
fix(core): match teams by stored-key pubkey in admin team-lookup

### DIFF
--- a/core/src/repositories/team.rs
+++ b/core/src/repositories/team.rs
@@ -49,11 +49,11 @@ impl TeamRepository {
         .map_err(Into::into)
     }
 
-    /// Search teams by name within a tenant. Returns up to `limit` rows whose
-    /// names match the case-insensitive substring `query`. Each row carries
-    /// the team's admin emails (for disambiguation when multiple teams share
-    /// a name) and a flag indicating whether the team has a stored key
-    /// (a team with no stored key is not eligible for `/support-access`).
+    /// Search teams by name or stored-key pubkey within a tenant. Returns up
+    /// to `limit` rows whose names match the case-insensitive substring
+    /// `query`, **or** whose stored key pubkey matches `query` exactly (hex).
+    /// Each row carries the team's admin emails (for disambiguation) and a
+    /// flag indicating whether the team has a stored key.
     ///
     /// Used by `GET /api/admin/team-lookup`.
     pub async fn search_by_name(
@@ -81,7 +81,14 @@ impl TeamRepository {
              LEFT JOIN team_users tu ON tu.team_id = t.id
              LEFT JOIN users u ON u.pubkey = tu.user_pubkey AND u.tenant_id = $1
              WHERE t.tenant_id = $1
-               AND t.name ILIKE $2
+               AND (
+                   t.name ILIKE $2
+                   OR EXISTS (
+                       SELECT 1 FROM stored_keys sk
+                       WHERE sk.team_id = t.id AND sk.tenant_id = $1
+                         AND sk.pubkey = $4
+                   )
+               )
              GROUP BY t.id, t.name, t.created_at
              ORDER BY t.name
              LIMIT $3",
@@ -89,6 +96,7 @@ impl TeamRepository {
         .bind(tenant_id)
         .bind(pattern)
         .bind(limit)
+        .bind(query)
         .fetch_all(&self.pool)
         .await
         .map_err(Into::into)


### PR DESCRIPTION
## Summary
- `GET /api/admin/team-lookup?q=<pubkey>` now also matches teams whose stored key pubkey equals the query (exact hex match), in addition to the existing case-insensitive name substring search.
- Fixes `synvya delete <npub>` failing with "No Keycast team found" when the team name doesn't match the relay profile name or when the query is a hex pubkey.

## Test plan
- [ ] Run `synvya delete <npub> --env staging --delete-all` against a team whose stored key matches the pubkey — should now find the team and proceed
- [ ] Verify name-based search still works: `synvya delete <npub>` where the team name matches the profile name
- [ ] Confirm passing a non-matching string (neither name nor pubkey) still returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)