### PR TITLE
Promote synvya-staging to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ ALLOWED_ORIGINS=https://keycast.example.com,https://peek.verse.app,https://*.ope
 # No default - must be explicitly set to prevent unintended external connections
 # The signer connects to these relays for NIP-46 communication
 # All bunker URLs will reference these relays (deployment-wide setting)
-BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol
+BUNKER_RELAYS=wss://relay.local.synvya.com
 
 # Optional: SendGrid API key for email sending (if not set, emails will be logged to console)
 SENDGRID_API_KEY=
@@ -90,9 +90,9 @@ VITE_ALLOWED_PUBKEYS=
 # NDK explicit relay URLs for reading/subscribing to Nostr events (comma-separated WebSocket URLs)
 # If not set, NDK will not connect to any external relays (no external connections)
 # Example: wss://relay.divine.video,wss://purplepag.es,wss://relay.nostr.band
-VITE_NDK_EXPLICIT_RELAYS=wss://relay.divine.video,wss://purplepag.es,wss://relay.nostr.band,wss://relay.snort.social,wss://relay.primal.net
+VITE_NDK_EXPLICIT_RELAYS=wss://relay.local.synvya.com
 
 # NDK bunker relay URLs for NIP-46 bunker communication (comma-separated WebSocket URLs)
 # If not set, bunker NDK will not connect to any external relays
 # Example: wss://relay.divine.video,wss://relay.primal.net
-VITE_NDK_BUNKER_RELAYS=wss://relay.divine.video,wss://relay.primal.net,wss://relay.nsec.app,wss://nos.lol
+VITE_NDK_BUNKER_RELAYS=wss://relay.local.synvya.com

--- a/core/src/repositories/team.rs
+++ b/core/src/repositories/team.rs
@@ -49,11 +49,11 @@ impl TeamRepository {
         .map_err(Into::into)
     }
 
-    /// Search teams by name within a tenant. Returns up to `limit` rows whose
-    /// names match the case-insensitive substring `query`. Each row carries
-    /// the team's admin emails (for disambiguation when multiple teams share
-    /// a name) and a flag indicating whether the team has a stored key
-    /// (a team with no stored key is not eligible for `/support-access`).
+    /// Search teams by name or stored-key pubkey within a tenant. Returns up
+    /// to `limit` rows whose names match the case-insensitive substring
+    /// `query`, **or** whose stored key pubkey matches `query` exactly (hex).
+    /// Each row carries the team's admin emails (for disambiguation) and a
+    /// flag indicating whether the team has a stored key.
     ///
     /// Used by `GET /api/admin/team-lookup`.
     pub async fn search_by_name(
@@ -81,7 +81,14 @@ impl TeamRepository {
              LEFT JOIN team_users tu ON tu.team_id = t.id
              LEFT JOIN users u ON u.pubkey = tu.user_pubkey AND u.tenant_id = $1
              WHERE t.tenant_id = $1
-               AND t.name ILIKE $2
+               AND (
+                   t.name ILIKE $2
+                   OR EXISTS (
+                       SELECT 1 FROM stored_keys sk
+                       WHERE sk.team_id = t.id AND sk.tenant_id = $1
+                         AND sk.pubkey = $4
+                   )
+               )
              GROUP BY t.id, t.name, t.created_at
              ORDER BY t.name
              LIMIT $3",
@@ -89,6 +96,7 @@ impl TeamRepository {
         .bind(tenant_id)
         .bind(pattern)
         .bind(limit)
+        .bind(query)
         .fetch_all(&self.pool)
         .await
         .map_err(Into::into)

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -29,9 +29,9 @@ elif [ "$ENV" = "production" ]; then
     INVITE_BASE_URL=https://account.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.synvya.com
     ADMIN_BASE_URL=https://admin.synvya.com
-    BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
-    VITE_NDK_EXPLICIT_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
-    VITE_NDK_BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
+    BUNKER_RELAYS=wss://relay.synvya.com
+    VITE_NDK_EXPLICIT_RELAYS=wss://relay.synvya.com
+    VITE_NDK_BUNKER_RELAYS=wss://relay.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -20,12 +20,18 @@ if [ "$ENV" = "staging" ]; then
     INVITE_BASE_URL=https://account.staging.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.staging.synvya.com
     ADMIN_BASE_URL=https://admin.staging.synvya.com
+    BUNKER_RELAYS=wss://relay.staging.synvya.com
+    VITE_NDK_EXPLICIT_RELAYS=wss://relay.staging.synvya.com
+    VITE_NDK_BUNKER_RELAYS=wss://relay.staging.synvya.com
 elif [ "$ENV" = "production" ]; then
     DOMAIN=auth.synvya.com
     KMS_KEY_ID=alias/synvya-production-keycast-masterkey
     INVITE_BASE_URL=https://account.synvya.com
     PASSWORD_RESET_BASE_URL=https://account.synvya.com
     ADMIN_BASE_URL=https://admin.synvya.com
+    BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
+    VITE_NDK_EXPLICIT_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
+    VITE_NDK_BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.synvya.com
 else
     echo "Error: environment must be 'staging' or 'production'" >&2
     exit 1
@@ -42,7 +48,9 @@ POSTGRES_PASSWORD=$(get_secret synvya/$ENV/keycast/postgres-password)
 SERVER_NSEC=$(get_secret synvya/$ENV/keycast/privatekey)
 AWS_KMS_KEY_ID=$KMS_KEY_ID
 AWS_REGION=$REGION
-BUNKER_RELAYS=wss://relay.damus.io,wss://nos.lol,wss://relay.snort.social
+BUNKER_RELAYS=$BUNKER_RELAYS
+VITE_NDK_EXPLICIT_RELAYS=$VITE_NDK_EXPLICIT_RELAYS
+VITE_NDK_BUNKER_RELAYS=$VITE_NDK_BUNKER_RELAYS
 ALLOWED_ORIGINS=https://$DOMAIN,$EXTRA_ALLOWED_ORIGINS
 BASE_URL=https://$DOMAIN
 APP_URL=https://$DOMAIN


### PR DESCRIPTION
## Summary
- Configure per-environment Nostr relay URLs (staging vs production)
- Use only `wss://relay.synvya.com` for production relay
- Fix admin team-lookup to match teams by stored-key pubkey

## Test plan
- [ ] Verify relay configuration is correct for production environment
- [ ] Confirm team lookup by pubkey works after deploy
- [ ] Smoke-test NIP-46 signing through production relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)