### PR TITLE
Include email in verify-email redirect URL

### DIFF
--- a/api/src/api/http/auth.rs
+++ b/api/src/api/http/auth.rs
@@ -1562,10 +1562,11 @@ pub async fn verify_email(
 
     // If the registration included a redirect_uri, redirect back to the client app
     let redirect_to = token_data.redirect_uri.map(|uri| {
+        let encoded_email = urlencoding::encode(&email);
         if uri.contains('?') {
-            format!("{}&verified=1", uri)
+            format!("{}&verified=1&email={}", uri, encoded_email)
         } else {
-            format!("{}?verified=1", uri)
+            format!("{}?verified=1&email={}", uri, encoded_email)
         }
     });
 


### PR DESCRIPTION
## Summary

- Appends the user's URL-encoded email to the verify-email redirect (`?verified=1&email=user%40example.com`)
- Allows the client login page to pre-fill and lock the email field after verification
- Uses the same `urlencoding::encode` pattern already in the admin claim flow (`admin.rs:748`)

## Context

After signing up on `account.synvya.com` and verifying their email, users were redirected back with only `?verified=1` — the email field was empty and they had to re-type it. The client (`Login.tsx`) already supports reading the `email` param when `verified=1` is present.

Closes #68

## Test plan

- [ ] Register a new user, verify email, confirm redirect includes `&email=<encoded>`
- [ ] Confirm the login page pre-fills and locks the email field
- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Verify `cargo fmt` passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)