### PR TITLE
Full admins bypass team membership in verify_admin

### DIFF
--- a/api/src/api/http/teams.rs
+++ b/api/src/api/http/teams.rs
@@ -575,6 +575,10 @@ pub async fn verify_admin<'a>(
     team_id: i32,
     tenant_id: i64,
 ) -> ApiResult<()> {
+    if is_full_admin_by_pubkey(pubkey_hex) {
+        return Ok(());
+    }
+
     let pubkey =
         PublicKey::from_hex(pubkey_hex).map_err(|_| ApiError::bad_request("Invalid pubkey"))?;
 
@@ -586,6 +590,16 @@ pub async fn verify_admin<'a>(
         )),
         Err(_) => Err(ApiError::auth("Failed to verify admin status")),
     }
+}
+
+fn is_full_admin_by_pubkey(pubkey_hex: &str) -> bool {
+    if let Ok(allowed_pubkeys) = std::env::var("ALLOWED_PUBKEYS") {
+        if !allowed_pubkeys.is_empty() {
+            let allowed: Vec<&str> = allowed_pubkeys.split(',').map(|s| s.trim()).collect();
+            return allowed.contains(&pubkey_hex);
+        }
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Full admins (pubkey in `ALLOWED_PUBKEYS`) can now `GET`, `PUT`, and `DELETE` any team without being a member
- Adds `is_full_admin_by_pubkey()` check at the top of `verify_admin()` before the team membership DB query
- Unblocks admin cleanup tooling for stale staging teams

Fixes #77

## Test plan
- [ ] Authenticate as a full admin (pubkey in `ALLOWED_PUBKEYS`)
- [ ] Verify `DELETE /api/teams/:id` works on a team the admin is not a member of
- [ ] Verify `GET /api/teams/:id` and `PUT /api/teams/:id` also work
- [ ] Verify non-admin users still get 403 on teams they don't belong to

🤖 Generated with [Claude Code](https://claude.com/claude-code)