### PR TITLE
Add restaurant key pubkeys to team-lookup API response

### DIFF
--- a/api/src/api/http/admin.rs
+++ b/api/src/api/http/admin.rs
@@ -16,7 +16,7 @@ use crate::state::{get_key_manager, get_secret_pool};
 use keycast_core::bunker_key::derive_bunker_keys;
 use keycast_core::repositories::{
     AuthorizationRepository, ClaimTokenRepository, OAuthAuthorizationRepository, PolicyRepository,
-    StoredKeyRepository, TeamRepository, TeamSearchResult, UserRepository,
+    RestaurantKeySummary, StoredKeyRepository, TeamRepository, TeamSearchResult, UserRepository,
 };
 use keycast_core::types::authorization::Authorization;
 use keycast_core::types::claim_token::generate_claim_token;
@@ -968,6 +968,8 @@ pub struct TeamLookupCandidate {
     /// key is not eligible for `POST /admin/teams/:id/support-access`; the
     /// client should surface this so support agents see why.
     pub has_stored_key: bool,
+    /// Name + pubkey of each stored key belonging to the team.
+    pub restaurant_keys: Vec<RestaurantKeySummary>,
     pub created_at: String,
 }
 
@@ -978,6 +980,7 @@ impl From<TeamSearchResult> for TeamLookupCandidate {
             name: row.name,
             admin_emails: row.admin_emails,
             has_stored_key: row.has_stored_key,
+            restaurant_keys: row.restaurant_keys.0,
             created_at: row.created_at.to_rfc3339(),
         }
     }

--- a/api/tests/admin_team_lookup_test.rs
+++ b/api/tests/admin_team_lookup_test.rs
@@ -64,14 +64,15 @@ async fn ensure_user_with_email(pool: &PgPool, tenant_id: i64, pubkey: &str, ema
     .expect("ensure_user_with_email insert must succeed");
 }
 
-/// Create a team with the given admin and (optionally) a stored key. Returns team_id.
+/// Create a team with the given admin and (optionally) a stored key.
+/// Returns `(team_id, Option<stored_key_pubkey>)`.
 async fn create_team(
     pool: &PgPool,
     tenant_id: i64,
     name: &str,
     admin_pubkey: &str,
     with_stored_key: bool,
-) -> i32 {
+) -> (i32, Option<String>) {
     ensure_tenant(pool, tenant_id).await;
     ensure_user_with_email(pool, tenant_id, admin_pubkey, None).await;
 
@@ -82,7 +83,7 @@ async fn create_team(
         .await
         .expect("create_with_admin should succeed");
 
-    if with_stored_key {
+    let stored_pubkey = if with_stored_key {
         let pubkey_hex = Keys::generate().public_key().to_hex();
         sqlx::query(
             "INSERT INTO stored_keys (tenant_id, team_id, name, pubkey, secret_key, created_at, updated_at)
@@ -95,9 +96,12 @@ async fn create_team(
         .execute(pool)
         .await
         .expect("stored_key insert should succeed");
-    }
+        Some(pubkey_hex)
+    } else {
+        None
+    };
 
-    twr.team.id
+    (twr.team.id, stored_pubkey)
 }
 
 async fn cleanup_team(pool: &PgPool, tenant_id: i64, team_id: i32) {
@@ -137,8 +141,8 @@ async fn test_search_matches_substring_case_insensitive() {
     let target_name = format!("JoesDiner-{}", unique);
     let unrelated_name = format!("BellaBistro-{}", unique);
 
-    let target = create_team(&pool, TENANT_A, &target_name, &admin, true).await;
-    let unrelated = create_team(&pool, TENANT_A, &unrelated_name, &admin, true).await;
+    let (target, _) = create_team(&pool, TENANT_A, &target_name, &admin, true).await;
+    let (unrelated, _) = create_team(&pool, TENANT_A, &unrelated_name, &admin, true).await;
 
     let team_repo = TeamRepository::new(pool.clone());
     // Lowercase substring of the target name. Must match `JoesDiner-…`
@@ -216,7 +220,7 @@ async fn test_search_has_stored_key_flag() {
     let admin = Keys::generate().public_key().to_hex();
     let unique = Uuid::new_v4().to_string();
 
-    let with_key = create_team(
+    let (with_key, with_key_pubkey) = create_team(
         &pool,
         TENANT_A,
         &format!("WithKey {}", unique),
@@ -224,7 +228,7 @@ async fn test_search_has_stored_key_flag() {
         true,
     )
     .await;
-    let without_key =
+    let (without_key, _) =
         create_team(&pool, TENANT_A, &format!("NoKey {}", unique), &admin, false).await;
 
     let team_repo = TeamRepository::new(pool.clone());
@@ -245,6 +249,21 @@ async fn test_search_has_stored_key_flag() {
         "team without stored key must flag false"
     );
 
+    let rk_pubkeys: Vec<&str> = with
+        .restaurant_keys
+        .iter()
+        .map(|rk| rk.pubkey.as_str())
+        .collect();
+    assert_eq!(
+        rk_pubkeys,
+        vec![with_key_pubkey.as_deref().unwrap()],
+        "restaurant_keys must contain the stored key pubkey"
+    );
+    assert!(
+        without.restaurant_keys.is_empty(),
+        "team without stored key must have empty restaurant_keys"
+    );
+
     cleanup_team(&pool, TENANT_A, with_key).await;
     cleanup_team(&pool, TENANT_A, without_key).await;
 }
@@ -258,8 +277,8 @@ async fn test_search_is_tenant_scoped() {
     let unique = Uuid::new_v4().to_string();
     let shared_name = format!("Cross Tenant {}", unique);
 
-    let team_a = create_team(&pool, TENANT_A, &shared_name, &admin_a, true).await;
-    let team_b = create_team(&pool, TENANT_B, &shared_name, &admin_b, true).await;
+    let (team_a, _) = create_team(&pool, TENANT_A, &shared_name, &admin_a, true).await;
+    let (team_b, _) = create_team(&pool, TENANT_B, &shared_name, &admin_b, true).await;
 
     let team_repo = TeamRepository::new(pool.clone());
 
@@ -301,7 +320,7 @@ async fn test_search_respects_limit() {
     let mut team_ids = Vec::new();
 
     for i in 0..5 {
-        let id = create_team(
+        let (id, _) = create_team(
             &pool,
             TENANT_A,
             &format!("LimitTest {} {}", unique, i),

--- a/core/src/repositories/mod.rs
+++ b/core/src/repositories/mod.rs
@@ -32,6 +32,6 @@ pub use policy::PolicyRepository;
 pub use refresh_token::RefreshTokenRepository;
 pub use registered_client::RegisteredClientRepository;
 pub use stored_key::StoredKeyRepository;
-pub use team::{TeamRepository, TeamSearchResult};
+pub use team::{RestaurantKeySummary, TeamRepository, TeamSearchResult};
 pub use team_invitation::TeamInvitationRepository;
 pub use user::{AdminUserDetails, DeleteAccountResult, UserRepository, VerificationTokenData};

--- a/core/src/repositories/team.rs
+++ b/core/src/repositories/team.rs
@@ -11,6 +11,13 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx::PgPool;
 
+/// Name + pubkey summary for a stored key, used in team-lookup responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RestaurantKeySummary {
+    pub name: String,
+    pub pubkey: String,
+}
+
 /// Result row for the team-name search used by `GET /api/admin/team-lookup`.
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct TeamSearchResult {
@@ -23,6 +30,8 @@ pub struct TeamSearchResult {
     /// `true` when the team has at least one row in `stored_keys`. A team
     /// without a stored key is not eligible for `/support-access`.
     pub has_stored_key: bool,
+    /// Name + pubkey of each stored key belonging to the team.
+    pub restaurant_keys: sqlx::types::Json<Vec<RestaurantKeySummary>>,
 }
 
 /// Repository for team-related database operations.
@@ -76,7 +85,13 @@ impl TeamRepository {
                 EXISTS (
                     SELECT 1 FROM stored_keys sk
                     WHERE sk.team_id = t.id AND sk.tenant_id = $1
-                ) AS has_stored_key
+                ) AS has_stored_key,
+                COALESCE(
+                    (SELECT json_agg(json_build_object('name', sk.name, 'pubkey', sk.pubkey))
+                     FROM stored_keys sk
+                     WHERE sk.team_id = t.id AND sk.tenant_id = $1),
+                    '[]'::json
+                ) AS restaurant_keys
              FROM teams t
              LEFT JOIN team_users tu ON tu.team_id = t.id
              LEFT JOIN users u ON u.pubkey = tu.user_pubkey AND u.tenant_id = $1


### PR DESCRIPTION
## Summary
- Enriches `GET /api/admin/team-lookup` to include `restaurant_keys` (name + pubkey) alongside each team, so downstream clients can display restaurant npubs without per-team API calls
- Uses a correlated JSON subquery to aggregate stored keys without disturbing the existing GROUP BY for admin emails
- Keeps `has_stored_key` boolean for backward compatibility

Closes #79

## Test plan
- [ ] `cargo check` passes (compile-time SQL verification)
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo test --test admin_team_lookup_test --features integration-tests` — asserts `restaurant_keys` contains expected pubkeys and is empty when no stored key exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)